### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,8 @@ jobs:
   deploy:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Potential fix for [https://github.com/mohrm/workingdiary/security/code-scanning/2](https://github.com/mohrm/workingdiary/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `deploy` job. Since the job does not appear to require any write permissions, we will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures that the job has only the permissions it needs, reducing the risk of misuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
