### PR TITLE
Potential fix for code scanning alert no. 1 and 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
   deploy:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Angular CI
 
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mohrm/workingdiary/security/code-scanning/1](https://github.com/mohrm/workingdiary/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the `build` job. Based on the workflow's steps, the `build` job only needs `contents: read` to check out the repository and access files. This change will ensure that the `GITHUB_TOKEN` has the least privileges necessary to execute the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
