### PR TITLE
configure renovate.json so that package.json will exactly reflect the…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,11 @@
   ],
   "baseBranchPatterns": [
     "dep_updates"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["*"],
+      "rangeStrategy": "pin"
+    }
   ]
 }


### PR DESCRIPTION
… versions from the package-lock.json