### PR TITLE
Enable Jest coverage collection and enforce global thresholds; update AGENTS.md testing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ async function get(x) {
 
 ## Boundaries
 - ✅ **Always:** Implement changes in `src/` (and in `e2e/` when needed), run relevant tests, follow existing patterns used in `*.spec.ts` files, and apply naming conventions.
+- ✅ **Always:** When you change behavior or logic, add or update automated tests so coverage does not decrease compared to the previous baseline. Ideally, improve coverage with each change.
+- ✅ **Always:** If coverage improves after your change, raise coverage thresholds to match the new measured coverage values.
 - ⚠️ **Ask first:** Adding new runtime dependencies, major changes to the build/test pipeline (`angular.json`, CI scripts), or updates to PWA/service-worker configuration.
 - 🚫 **Never:** Commit secrets or API keys, edit files in `node_modules/`, or commit generated build artifacts (`dist/`).
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,21 @@ export default {
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
   testMatch: ['<rootDir>/src/**/*.spec.ts'],
   transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  collectCoverage: true,
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.spec.ts',
+    '!src/main.ts',
+    '!src/environments/**/*.ts',
+  ],
+  coverageDirectory: '<rootDir>/coverage/unit',
+  coverageReporters: ['text-summary', 'lcov', 'json-summary', 'cobertura'],
+  coverageThreshold: {
+    global: {
+      branches: 40,
+      functions: 63.41,
+      lines: 71.27,
+      statements: 71.08,
+    },
+  },
 };


### PR DESCRIPTION
### Motivation
- Ensure test coverage is collected and enforced as part of the Jest configuration to prevent regressions.
- Codify repository expectations that behavior changes must include tests and that coverage should not decrease.

### Description
- Update `jest.config.js` to enable coverage collection with `collectCoverage`, `collectCoverageFrom`, `coverageDirectory`, and `coverageReporters` settings.
- Add a global `coverageThreshold` to `jest.config.js` with explicit branch, function, line, and statement percentages.
- Update `AGENTS.md` to require adding or updating automated tests when changing behavior and to raise coverage thresholds when coverage improves.

### Testing
- Ran unit tests with `npm test` (Jest) to verify there are no regressions and the test suite completes successfully.
- Generated coverage reports at `coverage/unit` using the configured reporters to verify output is produced.
- Verified that the measured coverage meets the newly added global thresholds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65a39a76c832bbbaa6e78a8554e41)