### PR TITLE
test: increase unit coverage to 80%+

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,10 @@ export default {
   coverageReporters: ['text-summary', 'lcov', 'json-summary', 'cobertura'],
   coverageThreshold: {
     global: {
-      branches: 40,
-      functions: 63.41,
-      lines: 71.27,
-      statements: 71.08,
+      branches: 86.66,
+      functions: 98.78,
+      lines: 96,
+      statements: 96.25,
     },
   },
 };

--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.component.spec.ts
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.component.spec.ts
@@ -1,0 +1,96 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EventEmitter } from '@angular/core';
+
+import { AbschnittListeComponent } from './abschnitt-liste.component';
+import { PersistenceServiceService } from '../../../persistence-service.service';
+import { Section } from '../../../model/Section';
+import { Time } from '../../../model/Time';
+
+describe('AbschnittListeComponent', () => {
+  let component: AbschnittListeComponent;
+  let fixture: ComponentFixture<AbschnittListeComponent>;
+  let persistence: PersistenceServiceService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AbschnittListeComponent]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AbschnittListeComponent);
+    component = fixture.componentInstance;
+    persistence = TestBed.inject(PersistenceServiceService);
+    fixture.componentRef.setInput('day', '01.01.2024');
+    fixture.componentRef.setInput('stempelEreignis', new EventEmitter<Section>());
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('loads sections on init and on changes', () => {
+    const sections = [new Section(new Time(9, 0), new Time(10, 0), 'Büro')];
+    const loadSpy = jest.spyOn(persistence, 'loadSections').mockReturnValue(sections);
+
+    component.ngOnInit();
+    component.ngOnChanges({});
+
+    expect(loadSpy).toHaveBeenCalledTimes(2);
+    expect(component.abschnitte()).toEqual(sections);
+  });
+
+  it('appends emitted section and saves list', () => {
+    const emitter = new EventEmitter<Section>();
+    const existing = [new Section(new Time(8, 0), new Time(9, 0), 'A')];
+    const added = new Section(new Time(9, 0), new Time(10, 0), 'B');
+    const saveSpy = jest.spyOn(persistence, 'saveSections');
+    jest.spyOn(persistence, 'loadSections').mockReturnValue(existing);
+
+    fixture.componentRef.setInput('stempelEreignis', emitter);
+    component.ngOnInit();
+    emitter.emit(added);
+
+    expect(component.abschnitte()).toEqual([...existing, added]);
+    expect(saveSpy).toHaveBeenCalledWith('01.01.2024', [...existing, added]);
+  });
+
+  it('creates list when old sections are undefined', () => {
+    const emitter = new EventEmitter<Section>();
+    const added = new Section(new Time(9, 0), new Time(10, 0), 'B');
+    jest.spyOn(persistence, 'loadSections').mockReturnValue(undefined);
+
+    fixture.componentRef.setInput('stempelEreignis', emitter);
+    component.ngOnInit();
+    emitter.emit(added);
+
+    expect(component.abschnitte()).toEqual([added]);
+  });
+
+  it('removes section by index', () => {
+    const sections = [
+      new Section(new Time(8, 0), new Time(9, 0), 'A'),
+      new Section(new Time(9, 0), new Time(10, 0), 'B')
+    ];
+    const saveSpy = jest.spyOn(persistence, 'saveSections');
+    component.abschnitte.set(sections);
+
+    component.entferneAbschnitt(0);
+
+    expect(component.abschnitte()).toEqual([sections[1]]);
+    expect(saveSpy).toHaveBeenCalledWith('01.01.2024', [sections[1]]);
+  });
+
+  it('updates one section by index', () => {
+    const sections = [
+      new Section(new Time(8, 0), new Time(9, 0), 'A'),
+      new Section(new Time(9, 0), new Time(10, 0), 'B')
+    ];
+    const replacement = new Section(new Time(8, 15), new Time(9, 15), 'Neu');
+    component.abschnitte.set(sections);
+
+    component.aendereAbschnitt(0, replacement);
+
+    expect(component.abschnitte()).toEqual([replacement, sections[1]]);
+  });
+});

--- a/src/app/feature/day-plan/abschnitt/abschnitt.component.spec.ts
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.component.spec.ts
@@ -12,7 +12,7 @@ describe('AbschnittComponent', () => {
     await TestBed.configureTestingModule({
       imports: [AbschnittComponent]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(AbschnittComponent);
     component = fixture.componentInstance;
@@ -25,5 +25,38 @@ describe('AbschnittComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('enters edit mode and pre-populates fields', () => {
+    component.setEditable();
+
+    expect(component.isEdit()).toBe(true);
+    expect(component.startHour()).toBe(9);
+    expect(component.startMinute()).toBe(0);
+    expect(component.endHour()).toBe(10);
+    expect(component.endMinute()).toBe(0);
+    expect(component.location()).toBe('Büro');
+  });
+
+  it('resets edit mode on abort', () => {
+    component.setEditable();
+
+    component.abortEdit();
+
+    expect(component.isEdit()).toBe(false);
+  });
+
+  it('saves edited section values', () => {
+    component.setEditable();
+    component.startHour.set(8);
+    component.startMinute.set(30);
+    component.endHour.set(11);
+    component.endMinute.set(45);
+    component.location.set('Homeoffice');
+
+    component.finishEdit();
+
+    expect(component.isEdit()).toBe(false);
+    expect(component.section()).toEqual(new Section(new Time(8, 30), new Time(11, 45), 'Homeoffice'));
   });
 });

--- a/src/app/feature/day-plan/day-plan.spec.ts
+++ b/src/app/feature/day-plan/day-plan.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DayPlan } from './day-plan';
+import { Section } from '../../model/Section';
+import { Time } from '../../model/Time';
 
 describe('DayPlanComponent', () => {
   let component: DayPlan;
@@ -10,7 +12,7 @@ describe('DayPlanComponent', () => {
     await TestBed.configureTestingModule({
       imports: [DayPlan]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(DayPlan);
     component = fixture.componentInstance;
@@ -20,5 +22,23 @@ describe('DayPlanComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('forwards checkout events to stempel event emitter', () => {
+    const emitSpy = jest.spyOn(component.stempelUhrEreignis, 'emit');
+    const section = new Section(new Time(9, 0), new Time(10, 0), 'Büro');
+
+    component.benutzerHatAusgestempelt(section);
+
+    expect(emitSpy).toHaveBeenCalledWith(section);
+  });
+
+  it('forwards section change events', () => {
+    const emitSpy = jest.spyOn(component.abschnitteAenderungsEreignis, 'emit');
+    const sections = [new Section(new Time(9, 0), new Time(10, 0), 'Büro')];
+
+    component.abschnitteGeaendert(sections);
+
+    expect(emitSpy).toHaveBeenCalledWith(sections);
   });
 });

--- a/src/app/feature/day-plan/stempeluhr/stempeluhr.component.spec.ts
+++ b/src/app/feature/day-plan/stempeluhr/stempeluhr.component.spec.ts
@@ -1,24 +1,110 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EventEmitter } from '@angular/core';
 
 import { StempeluhrComponent } from './stempeluhr.component';
+import { PersistenceServiceService } from '../../../persistence-service.service';
+import { Time } from '../../../model/Time';
+import { Section } from '../../../model/Section';
 
 describe('StempeluhrComponent', () => {
   let component: StempeluhrComponent;
   let fixture: ComponentFixture<StempeluhrComponent>;
+  let persistence: PersistenceServiceService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [StempeluhrComponent]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(StempeluhrComponent);
     component = fixture.componentInstance;
+    persistence = TestBed.inject(PersistenceServiceService);
     fixture.componentRef.setInput('day', '01.01.2024');
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('loads start time on init and on changes', () => {
+    const loaded = new Time(9, 15);
+    const loadSpy = jest.spyOn(persistence, 'loadStartTime').mockReturnValue(loaded);
+
+    component.ngOnInit();
+    component.ngOnChanges({});
+
+    expect(loadSpy).toHaveBeenCalledTimes(2);
+    expect(component.startTime()).toEqual(loaded);
+  });
+
+  it('enables edit mode with current start time', () => {
+    component.startTime.set(new Time(7, 25));
+
+    component.setEditable();
+
+    expect(component.isEdit()).toBe(true);
+    expect(component.hour()).toBe(7);
+    expect(component.minute()).toBe(25);
+  });
+
+  it('aborts edit mode', () => {
+    component.isEdit.set(true);
+
+    component.abortEdit();
+
+    expect(component.isEdit()).toBe(false);
+  });
+
+  it('persists manually edited time', () => {
+    component.hour.set(11);
+    component.minute.set(55);
+    component.isEdit.set(true);
+
+    component.finishEdit();
+
+    expect(component.startTime()).toEqual(new Time(11, 55));
+    expect(component.isEdit()).toBe(false);
+  });
+
+  it('stamps in once and saves start time', () => {
+    const now = new Time(8, 0);
+    const nowSpy = jest.spyOn(Time, 'now').mockReturnValue(now);
+    const saveSpy = jest.spyOn(persistence, 'saveStartTime');
+
+    component.startTime.set(undefined);
+    component.einstempeln();
+
+    expect(component.startTime()).toEqual(now);
+    expect(saveSpy).toHaveBeenCalledWith('01.01.2024', now);
+    nowSpy.mockRestore();
+  });
+
+  it('throws when stamping in twice', () => {
+    component.startTime.set(new Time(8, 0));
+
+    expect(() => component.einstempeln()).toThrow('Kann nicht einstempeln');
+  });
+
+  it('stamps out, emits section and clears start time', () => {
+    const now = new Time(12, 5);
+    const nowSpy = jest.spyOn(Time, 'now').mockReturnValue(now);
+    const emitSpy = jest.spyOn(component.stempelEreignis, 'emit');
+    const saveSpy = jest.spyOn(persistence, 'saveStartTime');
+
+    component.startTime.set(new Time(9, 0));
+    component.ausstempeln();
+
+    expect(emitSpy).toHaveBeenCalledWith(new Section(new Time(9, 0), now));
+    expect(component.startTime()).toBeUndefined();
+    expect(saveSpy).toHaveBeenCalledWith('01.01.2024', undefined);
+    nowSpy.mockRestore();
+  });
+
+  it('throws when stamping out without start time', () => {
+    component.startTime.set(undefined);
+
+    expect(() => component.ausstempeln()).toThrow('Kann nicht ausstempeln');
   });
 });

--- a/src/app/model/Time.spec.ts
+++ b/src/app/model/Time.spec.ts
@@ -1,0 +1,39 @@
+import { Time } from './Time';
+
+describe('Time', () => {
+  it('converts to minutes and industrial formats', () => {
+    const time = new Time(1, 30);
+
+    expect(time.inMinutes()).toBe(90);
+    expect(time.industrial()).toBe(1.5);
+    expect(time.industrialQuarterPrecision()).toBe(1.5);
+  });
+
+  it('rounds to quarter-hour precision', () => {
+    const time = new Time(1, 8);
+
+    expect(time.industrialQuarterPrecision()).toBe(1.25);
+  });
+
+  it('formats as HH:mm with leading zeros', () => {
+    const time = new Time(9, 5);
+
+    expect(time.formattedString()).toBe('09:05');
+  });
+
+  it('serializes and deserializes with json helpers', () => {
+    const time = new Time(13, 47);
+
+    expect(time.toJSON()).toEqual({ hour: 13, minute: 47 });
+    expect(Time.fromJSON({ hour: 13, minute: 47 })).toEqual(time);
+  });
+
+  it('creates current time with now()', () => {
+    const fixedDate = new Date(2026, 3, 8, 14, 22);
+    const dateSpy = jest.spyOn(global, 'Date').mockImplementation(() => fixedDate as unknown as string);
+
+    expect(Time.now()).toEqual(new Time(14, 22));
+
+    dateSpy.mockRestore();
+  });
+});

--- a/src/app/persistence-service.service.spec.ts
+++ b/src/app/persistence-service.service.spec.ts
@@ -10,10 +10,51 @@ describe('PersistenceServiceService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(PersistenceServiceService);
+    localStorage.clear();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('initializes plans storage when empty', () => {
+    expect(localStorage.getItem('plans')).toBeNull();
+
+    const plans = service.loadPlans();
+
+    expect(plans).toEqual({});
+    expect(localStorage.getItem('plans')).toBe('{}');
+  });
+
+  it('saves and loads start time', () => {
+    const day = '01.01.2024';
+    const start = new Time(9, 30);
+
+    service.saveStartTime(day, start);
+
+    expect(service.loadStartTime(day)).toEqual(start);
+  });
+
+  it('clears start time when undefined is saved', () => {
+    const day = '01.01.2024';
+
+    service.saveStartTime(day, new Time(8, 0));
+    service.saveStartTime(day, undefined);
+
+    expect(service.loadStartTime(day)).toBeUndefined();
+  });
+
+  it('saves and loads sections', () => {
+    const day = '01.01.2024';
+    const sections = [new Section(new Time(9, 0), new Time(10, 0), 'Büro')];
+
+    service.saveSections(day, sections);
+
+    expect(service.loadSections(day)).toEqual(sections);
+  });
+
+  it('returns undefined when no sections are available', () => {
+    expect(service.loadSections('01.01.2024')).toBeUndefined();
   });
 
   it('emits section updates when saving sections', (done) => {
@@ -27,5 +68,21 @@ describe('PersistenceServiceService', () => {
     });
 
     service.saveSections(day, sections);
+  });
+
+  it('returns previous day if available, otherwise current day', () => {
+    service.saveSections('01.01.2024', []);
+    service.saveSections('03.01.2024', []);
+
+    expect(service.previousDay('03.01.2024')).toBe('01.01.2024');
+    expect(service.previousDay('01.01.2024')).toBe('01.01.2024');
+  });
+
+  it('returns next day if available, otherwise current day', () => {
+    service.saveSections('01.01.2024', []);
+    service.saveSections('03.01.2024', []);
+
+    expect(service.nextDay('01.01.2024')).toBe('03.01.2024');
+    expect(service.nextDay('03.01.2024')).toBe('03.01.2024');
   });
 });

--- a/src/app/version.service.spec.ts
+++ b/src/app/version.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 
 import { VersionService } from './version.service';
+import { commitHash, commitTimestamp, urlOfLastCommit } from '../environments/version';
 
 describe('VersionService', () => {
   let service: VersionService;
@@ -12,5 +13,16 @@ describe('VersionService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('returns full version text', () => {
+    expect(service.getVersion()).toContain(commitTimestamp);
+    expect(service.getVersion()).toContain(commitHash);
+  });
+
+  it('returns commit metadata fields', () => {
+    expect(service.commitTimestamp()).toBe(commitTimestamp);
+    expect(service.commitHash()).toBe(commitHash);
+    expect(service.urlOfLastCommit()).toBe(urlOfLastCommit);
   });
 });


### PR DESCRIPTION
### Motivation
- Raise unit test coverage above the 80% target and cover previously untested logic in models and day-plan components.
- Ensure persistence and version helpers behave correctly across edge cases (serialisation, date navigation, event emission).

### Description
- Added `src/app/model/Time.spec.ts` to exercise `Time` helpers including `now()`, formatting and JSON helpers.
- Implemented comprehensive specs for day-plan features by adding `abschnitt-liste` tests and expanding `stempeluhr`, `abschnitt`, and `day-plan` specs to cover edit flows, event forwarding and persistence interactions.
- Extended `persistence-service.service.spec.ts` and `version.service.spec.ts` to validate storage init, start/section persistence, previous/next day logic and version metadata access.
- Updated `jest.config.js` global coverage thresholds to match the new measured baseline.

### Testing
- Ran `npm test -- --coverage --runInBand` which passed all suites and produced coverage: Statements 96.25%, Branches 86.66%, Functions 98.78%, Lines 96%.
- Ran `npm test -- --runInBand` (without coverage) which also succeeded with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65cce6078832ba7424042f7cf0012)