### PR TITLE
Call weekly ng update script from workflow and add run-weekly-ng-update.sh

### DIFF
--- a/.github/workflows/weekly-ng-update.yml
+++ b/.github/workflows/weekly-ng-update.yml
@@ -80,9 +80,9 @@ jobs:
         if: steps.precheck.outputs.should_run == 'true'
         run: npx ng version
 
-      - name: Run ng update
+      - name: Run weekly ng update script
         if: steps.precheck.outputs.should_run == 'true'
-        run: npx ng update
+        run: bash ./scripts/run-weekly-ng-update.sh
 
       - name: Check for changes
         if: steps.precheck.outputs.should_run == 'true'

--- a/scripts/run-weekly-ng-update.sh
+++ b/scripts/run-weekly-ng-update.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly PACKAGE_JSON_PATH="package.json"
+
+if [[ ! -f "${PACKAGE_JSON_PATH}" ]]; then
+  echo "Fehler: ${PACKAGE_JSON_PATH} wurde nicht gefunden."
+  exit 1
+fi
+
+COMPILER_RESULT="$(
+  node -e '
+    const fs = require("node:fs");
+    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+    const dependencies = packageJson.dependencies ?? {};
+    const devDependencies = packageJson.devDependencies ?? {};
+    const coreVersion = dependencies["@angular/core"] ?? devDependencies["@angular/core"] ?? "";
+    const hasCompiler = Boolean(dependencies["@angular/compiler"] ?? devDependencies["@angular/compiler"]);
+
+    if (!coreVersion || hasCompiler) {
+      process.stdout.write("noop");
+      process.exit(0);
+    }
+
+    dependencies["@angular/compiler"] = coreVersion;
+    packageJson.dependencies = dependencies;
+    fs.writeFileSync("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
+    process.stdout.write(`added:${coreVersion}`);
+  '
+)"
+
+if [[ "${COMPILER_RESULT}" == added:* ]]; then
+  echo "Ergänze fehlendes @angular/compiler in package.json (${COMPILER_RESULT#added:}), damit ng-update-Migrationen laufen."
+fi
+
+echo "Prüfe verfügbare Updates (informativ)..."
+if ! npx ng update; then
+  echo "Hinweis: 'ng update' (ohne Paketliste) lieferte keinen erfolgreichen Exit-Code. Fahre mit gezieltem Update fort."
+fi
+
+mapfile -t UPDATE_PACKAGES < <(
+  node -e '
+    const fs = require("node:fs");
+    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+    const deps = [
+      ...Object.keys(packageJson.dependencies ?? {}),
+      ...Object.keys(packageJson.devDependencies ?? {}),
+    ];
+    const selected = deps
+      .filter((name) => name.startsWith("@angular/"))
+      .filter((name) => name !== "@angular/compiler");
+
+    for (const name of [...new Set(selected)].sort()) {
+      process.stdout.write(`${name}\n`);
+    }
+  '
+)
+
+if [[ "${#UPDATE_PACKAGES[@]}" -eq 0 ]]; then
+  echo "Keine passenden Angular-Pakete für ein Update gefunden."
+  exit 0
+fi
+
+echo "Wende Updates für folgende Pakete an: ${UPDATE_PACKAGES[*]}"
+npx ng update "${UPDATE_PACKAGES[@]}" --force --allow-dirty --verbose


### PR DESCRIPTION
### Motivation

- Make the weekly Angular update workflow more robust by encapsulating the update logic in a script rather than running a bare `npx ng update` step.
- Ensure migrations that require `@angular/compiler` run correctly by automatically adding a missing `@angular/compiler` entry matching `@angular/core` when needed.

### Description

- Replace the workflow step `Run ng update` with `Run weekly ng update script` and invoke `bash ./scripts/run-weekly-ng-update.sh` from `.github/workflows/weekly-ng-update.yml`.
- Add `scripts/run-weekly-ng-update.sh` which verifies `package.json` exists, adds `@angular/compiler` if missing (matching `@angular/core`), runs an informational `npx ng update`, collects all `@angular/*` packages (except `@angular/compiler`) and runs `npx ng update` for those packages with `--force --allow-dirty --verbose`.
- Make the new script strict (`set -euo pipefail`), emit user-facing messages in German, and exit early when no Angular packages are present.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d751f6ac98832bb6cd83f3b38cdd73)