### PR TITLE
chore(workflow): weekly Angular update uses script and PAT-backed token

### DIFF
--- a/.github/workflows/weekly-ng-update.yml
+++ b/.github/workflows/weekly-ng-update.yml
@@ -16,12 +16,22 @@ concurrency:
 jobs:
   ng-update:
     runs-on: ubuntu-latest
+    env:
+      GH_WORKFLOW_TOKEN: ${{ secrets.PAT }}
 
     steps:
+      - name: Verify workflow token
+        run: |
+          if [[ -z "${GH_WORKFLOW_TOKEN}" ]]; then
+            echo "Fehler: Secret PAT ist nicht gesetzt. Bitte Personal Access Token mit Repo-Rechten als Secret 'PAT' hinterlegen."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ env.GH_WORKFLOW_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -36,6 +46,7 @@ jobs:
         id: precheck
         uses: actions/github-script@v8
         with:
+          github-token: ${{ env.GH_WORKFLOW_TOKEN }}
           script: |
             const branchName = 'chore/weekly-ng-update';
             const owner = context.repo.owner;
@@ -80,9 +91,9 @@ jobs:
         if: steps.precheck.outputs.should_run == 'true'
         run: npx ng version
 
-      - name: Run ng update
+      - name: Run weekly ng update script
         if: steps.precheck.outputs.should_run == 'true'
-        run: npx ng update
+        run: bash ./scripts/run-weekly-ng-update.sh
 
       - name: Check for changes
         if: steps.precheck.outputs.should_run == 'true'
@@ -107,6 +118,7 @@ jobs:
         if: steps.precheck.outputs.should_run == 'true' && steps.changes.outputs.has_changes == 'true'
         uses: actions/github-script@v8
         with:
+          github-token: ${{ env.GH_WORKFLOW_TOKEN }}
           script: |
             const branchName = '${{ steps.precheck.outputs.branch_name }}';
             await github.rest.pulls.create({

--- a/scripts/run-weekly-ng-update.sh
+++ b/scripts/run-weekly-ng-update.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly PACKAGE_JSON_PATH="package.json"
+
+if [[ ! -f "${PACKAGE_JSON_PATH}" ]]; then
+  echo "Fehler: ${PACKAGE_JSON_PATH} wurde nicht gefunden."
+  exit 1
+fi
+
+COMPILER_RESULT="$(
+  node -e '
+    const fs = require("node:fs");
+    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+    const dependencies = packageJson.dependencies ?? {};
+    const devDependencies = packageJson.devDependencies ?? {};
+    const coreVersion = dependencies["@angular/core"] ?? devDependencies["@angular/core"] ?? "";
+    const hasCompiler = Boolean(dependencies["@angular/compiler"] ?? devDependencies["@angular/compiler"]);
+
+    if (!coreVersion || hasCompiler) {
+      process.stdout.write("noop");
+      process.exit(0);
+    }
+
+    dependencies["@angular/compiler"] = coreVersion;
+    packageJson.dependencies = dependencies;
+    fs.writeFileSync("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
+    process.stdout.write(`added:${coreVersion}`);
+  '
+)"
+
+if [[ "${COMPILER_RESULT}" == added:* ]]; then
+  echo "Ergänze fehlendes @angular/compiler in package.json (${COMPILER_RESULT#added:}), damit ng-update-Migrationen laufen."
+fi
+
+echo "Prüfe verfügbare Updates (informativ)..."
+if ! npx ng update; then
+  echo "Hinweis: 'ng update' (ohne Paketliste) lieferte keinen erfolgreichen Exit-Code. Fahre mit gezieltem Update fort."
+fi
+
+mapfile -t UPDATE_PACKAGES < <(
+  node -e '
+    const fs = require("node:fs");
+    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+    const deps = [
+      ...Object.keys(packageJson.dependencies ?? {}),
+      ...Object.keys(packageJson.devDependencies ?? {}),
+    ];
+    const selected = deps
+      .filter((name) => name.startsWith("@angular/"))
+      .filter((name) => name !== "@angular/compiler");
+
+    for (const name of [...new Set(selected)].sort()) {
+      process.stdout.write(`${name}\n`);
+    }
+  '
+)
+
+if [[ "${#UPDATE_PACKAGES[@]}" -eq 0 ]]; then
+  echo "Keine passenden Angular-Pakete für ein Update gefunden."
+  exit 0
+fi
+
+echo "Wende Updates für folgende Pakete an: ${UPDATE_PACKAGES[*]}"
+npx ng update "${UPDATE_PACKAGES[@]}" --force --allow-dirty --verbose


### PR DESCRIPTION
### Motivation
- Automate and harden the weekly Angular dependency update workflow so PRs can be created reliably. 
- Ensure the workflow has a usable token for `actions/checkout` and GitHub API calls to avoid permission issues when creating branches and PRs. 
- Make `ng update` more robust by handling missing `@angular/compiler` and performing targeted updates for installed `@angular/*` packages.

### Description
- Add `GH_WORKFLOW_TOKEN` from secret `PAT`, verify it's present at job start, and pass it to `actions/checkout` and `actions/github-script` steps. 
- Replace the one-liner `npx ng update` with a new script `scripts/run-weekly-ng-update.sh` and update the workflow to call that script. 
- Implement `scripts/run-weekly-ng-update.sh` to validate `package.json`, add a matching `@angular/compiler` if missing, list installed `@angular/*` packages (excluding `@angular/compiler`), and run `npx ng update` for those packages with `--force --allow-dirty --verbose`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d751f6ac98832bb6cd83f3b38cdd73)