### PR TITLE
ci: trigger Angular CI from Weekly Angular Update via repository_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  repository_dispatch:
+    types: [run-angular-ci]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -32,7 +34,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v6
-      
+
+      - name: Debug repository_dispatch payload
+        run: echo '${{ toJson(github.event.client_payload) }}'
+
       - name: npm install and npm run CI commands
         run: ./scripts/ci-install-and-build.sh
       - name: run jest tests

--- a/.github/workflows/weekly-ng-update.yml
+++ b/.github/workflows/weekly-ng-update.yml
@@ -138,3 +138,22 @@ jobs:
       - name: No changes after ng update
         if: steps.precheck.outputs.should_run == 'true' && steps.changes.outputs.has_changes != 'true'
         run: echo "`ng update` hat keine Änderungen erzeugt."
+
+      - name: Trigger Angular CI via repository_dispatch
+        if: ${{ success() }}
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          curl -sS -X POST "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${PAT_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d @- <<'JSON'
+          {
+            "event_type": "run-angular-ci",
+            "client_payload": {
+              "source": "Weekly Angular Update",
+              "ref": "${{ github.ref }}"
+            }
+          }
+          JSON


### PR DESCRIPTION
### Motivation

- Ensure the `Angular CI` workflow runs reliably when `Weekly Angular Update` finishes, regardless of how the update workflow was started (schedule, manual, etc.).
- Provide an explicit, repository-level trigger that is independent of `push`/`pull_request` contexts so `Angular CI` can run without a PR context.

### Description

- Added a final step to `Weekly Angular Update` (`.github/workflows/weekly-ng-update.yml`) that posts a `repository_dispatch` to `https://api.github.com/repos/${{ github.repository }}/dispatches` using `event_type: run-angular-ci`, authenticating with `${{ secrets.PAT_TOKEN }}`, and including `client_payload` with `source: "Weekly Angular Update"` and `ref: "${{ github.ref }}"`.
- The dispatch step is conditional on prior steps succeeding and uses `if: ${{ success() }}` to avoid firing on failed runs.
- Updated `Angular CI` (`.github/workflows/build.yml`) to preserve existing `push`, `pull_request`, and `workflow_dispatch` triggers and to add `repository_dispatch: types: [run-angular-ci]` so it reacts to the new event.
- Added a debug step at the start of the `Angular CI` job to print `github.event.client_payload` (`echo '${{ toJson(github.event.client_payload) }}'`) so the workflow can handle runs without standard PR metadata.

### Testing

- Validated both updated workflow files parse as YAML using `ruby -e 'require "yaml"; YAML.load_file(...)'`, and the check succeeded for both files.
- Attempted a Python `yaml.safe_load` check but it failed in this environment due to missing `PyYAML` (automated check failure unrelated to YAML content).
- Confirmed the changes by inspecting the resulting diffs and ensuring the inserted `repository_dispatch` step and trigger block appear in the modified workflow files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e487b4f9c0832b924e3f698588c870)