### PR TITLE
ci: gate weekly repository_dispatch on changed PR and run for branch+PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ permissions:
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   repository_dispatch:
     types: [run-angular-ci]
 
@@ -34,6 +34,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.ref || github.ref }}
 
       - name: Debug repository_dispatch payload
         run: echo '${{ toJson(github.event.client_payload) }}'
@@ -82,7 +84,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-
 
     steps:
       - name: Download build artifact
@@ -139,7 +140,3 @@ jobs:
           docker-compose up -d workingdiary && \
           docker image prune -a -f
           EOF
-    
-          
-          
-      

--- a/.github/workflows/weekly-ng-update.yml
+++ b/.github/workflows/weekly-ng-update.yml
@@ -2,7 +2,7 @@ name: Weekly Angular Update
 
 on:
   schedule:
-    - cron: '0 3 * * 0'
+    - cron: "0 3 * * 0"
   workflow_dispatch:
 
 permissions:
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           cache: npm
 
       - name: Install dependencies
@@ -116,12 +116,13 @@ jobs:
 
       - name: Create pull request
         if: steps.precheck.outputs.should_run == 'true' && steps.changes.outputs.has_changes == 'true'
+        id: create_pr
         uses: actions/github-script@v9
         with:
           github-token: ${{ env.GH_WORKFLOW_TOKEN }}
           script: |
             const branchName = '${{ steps.precheck.outputs.branch_name }}';
-            await github.rest.pulls.create({
+            const pr = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: 'chore: weekly ng update',
@@ -135,25 +136,46 @@ jobs:
               ].join('\n'),
             });
 
+            core.setOutput('pr_number', String(pr.data.number));
+
       - name: No changes after ng update
         if: steps.precheck.outputs.should_run == 'true' && steps.changes.outputs.has_changes != 'true'
         run: echo "`ng update` hat keine Änderungen erzeugt."
 
       - name: Trigger Angular CI via repository_dispatch
-        if: ${{ success() }}
+        if: steps.precheck.outputs.should_run == 'true' && steps.changes.outputs.has_changes == 'true' && steps.create_pr.outputs.pr_number != ''
         env:
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
+          BRANCH_REF="${{ steps.precheck.outputs.branch_name }}"
+          PR_NUMBER="${{ steps.create_pr.outputs.pr_number }}"
+
           curl -sS -X POST "https://api.github.com/repos/${{ github.repository }}/dispatches" \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${PAT_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -d @- <<'JSON'
+            -d @- <<JSON
           {
             "event_type": "run-angular-ci",
             "client_payload": {
               "source": "Weekly Angular Update",
-              "ref": "${{ github.ref }}"
+              "run_for": "branch",
+              "ref": "${BRANCH_REF}"
+            }
+          }
+          JSON
+
+          curl -sS -X POST "https://api.github.com/repos/${{ github.repository }}/dispatches" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${PAT_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d @- <<JSON
+          {
+            "event_type": "run-angular-ci",
+            "client_payload": {
+              "source": "Weekly Angular Update",
+              "run_for": "pull_request",
+              "ref": "refs/pull/${PR_NUMBER}/head"
             }
           }
           JSON


### PR DESCRIPTION
### Motivation

- The weekly `ng update` should only trigger the Angular CI dispatch when it actually produced changes and a pull request was created, and CI should run for both the update branch and the pull request head.
- The Angular CI workflow must be able to run against the ref provided in a `repository_dispatch` payload rather than always using the workflow's own `github.ref`.

### Description

- Update `build.yml` checkout to use the payload ref when the event is `repository_dispatch` by adding `with: ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.ref || github.ref }}` to `actions/checkout`.
- Update `weekly-ng-update.yml` to capture the created pull request number by setting `id: create_pr` and `core.setOutput('pr_number', String(pr.data.number))` after PR creation.
- Gate the `Trigger Angular CI via repository_dispatch` step so it only runs when the weekly update actually produced changes and a PR was created by requiring `steps.precheck.outputs.should_run == 'true' && steps.changes.outputs.has_changes == 'true' && steps.create_pr.outputs.pr_number != ''`.
- Dispatch Angular CI twice from the weekly workflow: once for the update branch (`ref` = branch name) and once for the PR head (`ref` = `refs/pull/<PR_NUMBER>/head`), and apply minor YAML formatting fixes.

### Testing

- Ran `npx prettier --check .github/workflows/build.yml .github/workflows/weekly-ng-update.yml`, which initially reported style issues and failed.
- Ran `npx prettier --write .github/workflows/build.yml .github/workflows/weekly-ng-update.yml` to fix formatting.
- Re-ran `npx prettier --check .github/workflows/build.yml .github/workflows/weekly-ng-update.yml` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edb92cff7c832b98c972c694a48da3)