### PR TITLE
Update renovate.json to remove TypeScript rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,16 +18,6 @@
       "automerge": true
     },
     {
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "typescript"
-      ],
-      "allowedVersions": "<7.0.0",
-      "rangeStrategy": "pin"
-    },
-    {
       "groupName": "Angular",
       "groupSlug": "angular",
       "matchPackageNames": [


### PR DESCRIPTION
Removed TypeScript version restriction from Renovate config.