### PR TITLE
Fix PWA cache invalidation by basing cache key on all asset filenames

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -111,7 +111,11 @@ async function scanDir(dir, prefix) {
 }
 
 const precacheFiles = await scanDir(DIST);
-const cacheKey = `workingdiary-v${cssHash}`;
+const urlsHash = crypto.createHash('sha256')
+  .update(precacheFiles.sort().join('|'))
+  .digest('hex')
+  .slice(0, 8);
+const cacheKey = `workingdiary-v${urlsHash}`;
 
 const sw = `const PRECACHE='${cacheKey}';const PRECACHE_URLS=${JSON.stringify(precacheFiles)};
 self.addEventListener('install',e=>{e.waitUntil(caches.open(PRECACHE).then(c=>c.addAll(PRECACHE_URLS)));self.skipWaiting()});

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -19,7 +19,7 @@ const lines = parseFloat(match[1]);
 const branches = parseFloat(match[2]);
 const functions = parseFloat(match[3]);
 
-const THRESHOLDS = { lines: 77.46, branches: 91.73, functions: 86.92 };
+const THRESHOLDS = { lines: 77.87, branches: 91.79, functions: 87.04 };
 const errors = [];
 
 if (lines < THRESHOLDS.lines) {

--- a/src/app/sw.spec.ts
+++ b/src/app/sw.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
@@ -40,10 +41,26 @@ describe('Service Worker', () => {
     assert.ok(sw.includes('self.clientsClaim()'));
   });
 
-  it('contains a cache key derived from CSS hash', () => {
+  it('contains a cache key derived from all asset filenames', () => {
     assert.ok(
       /PRECACHE='workingdiary-v[a-f0-9]{8}'/.test(sw),
       'cache key must contain 8-char hex hash',
     );
+  });
+
+  it('cache key changes when any asset file changes, not just CSS', () => {
+    const keyMatch = sw.match(/PRECACHE='([^']+)'/);
+    assert.ok(keyMatch);
+    const actualKey = keyMatch[1];
+
+    const urlsMatch = sw.match(/PRECACHE_URLS=\[(.*?)\]/);
+    assert.ok(urlsMatch);
+    const urls = JSON.parse(`[${urlsMatch[1]}]`) as string[];
+    assert.ok(urls.length > 0);
+
+    const sorted = [...urls].sort();
+    const expectedKey = `workingdiary-v${createHash('sha256').update(sorted.join('|')).digest('hex').slice(0, 8)}`;
+
+    assert.strictEqual(actualKey, expectedKey);
   });
 });


### PR DESCRIPTION
Problem: When JS files changed but CSS stayed the same, the SW cache key (previously derived only from CSS hash) remained unchanged. The activate handler skipped cache cleanup (it keeps the current-keyed cache), so old assets persisted alongside new ones, and clients served stale files.

Cause: The cache key used only the CSS hash, so JS-only changes produced the same key and the old cache was never invalidated.

Solution: Derive the cache key from a SHA-256 hash of all precached asset filenames (each already contains its own content hash via esbuild or the manual CSS hash). Any content change produces a different URL list -> different cache key -> activate deletes the old cache.