### PR TITLE
Add Cache-Control headers to nginx config for proper HTTP caching

### DIFF
--- a/nginx.default.conf.template
+++ b/nginx.default.conf.template
@@ -12,6 +12,19 @@ server {
     gzip_vary on;
     gzip_proxied any;
 
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location = /sw.js {
+        add_header Cache-Control "no-cache";
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
     location = /info/version {
         default_type application/json;
         return 200 '{"version":"__APP_VERSION__"}';

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -19,7 +19,7 @@ const lines = parseFloat(match[1]);
 const branches = parseFloat(match[2]);
 const functions = parseFloat(match[3]);
 
-const THRESHOLDS = { lines: 77.87, branches: 91.79, functions: 87.04 };
+const THRESHOLDS = { lines: 78.63, branches: 92.14, functions: 87.61 };
 const errors = [];
 
 if (lines < THRESHOLDS.lines) {

--- a/src/app/nginx-config.spec.ts
+++ b/src/app/nginx-config.spec.ts
@@ -1,0 +1,33 @@
+import { createHash } from 'node:crypto';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+describe('Nginx Config', () => {
+  const cfgPath = 'nginx.default.conf.template';
+
+  it('exists as a template file', () => {
+    assert.ok(existsSync(cfgPath));
+  });
+
+  it('sets no-cache on sw.js', () => {
+    const cfg = readFileSync(cfgPath, 'utf-8');
+    assert.ok(
+      /location\s*=\s*\/sw\.js\s*\{[\s\S]*?Cache-Control\s*"no-cache"/.test(cfg),
+    );
+  });
+
+  it('sets no-cache on index.html', () => {
+    const cfg = readFileSync(cfgPath, 'utf-8');
+    assert.ok(
+      /location\s*=\s*\/index\.html\s*\{[\s\S]*?Cache-Control\s*"no-cache"/.test(cfg),
+    );
+  });
+
+  it('sets immutable cache on /assets/', () => {
+    const cfg = readFileSync(cfgPath, 'utf-8');
+    assert.ok(
+      /location\s*\/assets\/\s*\{[\s\S]*?immutable/.test(cfg),
+    );
+  });
+});


### PR DESCRIPTION
Problem: Clients received different app versions (commits 24802db vs 8b0cf2f) because sw.js and index.html were served without any Cache- Control headers. Browsers cached them aggressively via HTTP cache, so the SW update mechanism never triggered.

Cause: The nginx config had no expires or Cache-Control directives. Files like sw.js and index.html (which must always be fresh) were cached indefinitely by default browser heuristics.

Solution: Added Cache-Control headers:
- /sw.js and /index.html → no-cache (always revalidate with server)
- /assets/* → public, immutable, expires 1y (content-hashed filenames)