### PR TITLE
refactor: streamline AGENTS.md from 81 to 49 lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,81 +1,58 @@
 ---
 name: vanillajs-dev-agent
-description: Builds and improves this Vanilla JS + Vite + TypeScript project, including components, services, styles, and tests.
+description: Builds and improves this Vanilla JS + Vite + TypeScript project.
 ---
 
-You are an expert frontend developer for this project.
+## Tech Stack
+esbuild 0.28.x, TypeScript 6.0.x, Sass, Node test runner (node:test + node:assert/strict) + tsx 4.23, Biome 2.5.4, Playwright 1.61 + playwright-bdd 9.2. No framework – pure Vanilla JS ES modules.
 
-## Persona
-- You specialize in building maintainable Vanilla JS applications, writing clean TypeScript, SCSS, and automated tests.
-- You understand this codebase — its factory-function components, SCSS layout, BDD E2E tests — and translate that into robust implementations and clear changes.
-- Your output: Vanilla JS components, SCSS styles, TypeScript models/services, and matching unit and E2E tests that help catch bugs early and keep the codebase maintainable.
+## Commands
+```bash
+npm run dev      # esbuild + Node server, port 5173, live-reload
+npm run build    # esbuild + sass-embedded + custom build
+npm run preview  # static server for dist/
+npm test         # node:test via tsx, auto-coverage, threshold check
+npm run e2e      # Playwright-BDD
+npm run lint     # biome check
+npm run format   # biome check --write
+```
 
-## Project knowledge
-- **Tech Stack:** esbuild 0.28.x, TypeScript 6.0.x, Sass (sass-embedded), Node built-in test runner (node:test + node:assert) + tsx 4.23, Biome 2.5.4 (linter + formatter), Playwright 1.61 + playwright-bdd 9.2.
-- **No framework:** The app uses Vanilla JS (ES modules), no Angular, no React, no RxJS, no Signals.
-- **Components:** Each feature is a factory function that returns `{ element, update, destroy? }` — see existing files in `src/app/feature/`.
-- **File Structure:**
-  - `src/app/` – Application code
-    - `app.js` – App shell (creates day-plan, abschnitt-summe, download-plans)
-    - `model/` – TypeScript model classes (`Time.ts`, `Section.ts`)
-    - `services/` – TypeScript services (`persistence.ts`, `version.ts`)
-    - `feature/` – Feature modules as Vanilla JS (`.js` + `.scss` per component)
-  - `src/styles.scss` – Global styles (Material Design button/icon/list replacements)
-  - `e2e/` – End-to-end tests with Playwright-BDD (features, steps, page objects, config)
-  - `biome.json` – Biome linter/formatter configuration
-  - `scripts/` – Build/CI helper scripts (`build.mjs`, `dev.mjs`, `preview.mjs`, `update-version.cjs`, `run-tests.sh`, `check-coverage.mjs`)
-  - `test-setup.ts` – Test environment setup (localStorage mock, EventTarget window)
-- **PWA / Service Worker:** Komplett dependency-frei implementiert. Der SW wird beim Build in `scripts/build.mjs` (Zeile ~116–120) aus einem Template mit injiziertem Precache-Manifest generiert → `dist/sw.js`. Die `registerSW`-Logik ist inline im `<head>` von `dist/index.html` (via `<script>...</script>`, kein separater HTTP-Request). Das `manifest.webmanifest` wird als statisches JSON geschrieben. Der SW cached `PRECACHE_URLS` bei `install`, aktiviert via `skipWaiting` + `clientsClaim`, und served bei `fetch` Navigationen aus dem Root-Cache, sonst Cache-First mit Network-Fallback. Der Cache-Key (`PRECACHE`) enthält den CSS-Content-Hash für automatische Invalidierung.
+## Code Style
+- Components: `.js` factory functions → `{ element, update, destroy? }`
+- Models/Services: `.ts` files
+- Styles: `.scss` per component, imported in `main.ts`
+- Tests: `node:test` + `node:assert/strict` (not Jest)
+- No comments unless intent unclear
 
-## Tools you can use
-- **Dev server:** `npm run dev` (starts esbuild + custom Node server on port 5173 with live-reload)
-- **Build:** `npm run build` (esbuild + sass-embedded + custom build script)
-- **Preview:** `npm run preview` (Node static server for dist/)
-- **Unit tests:** `npm test` (Node built-in test runner via tsx, collects coverage automatically via --experimental-test-coverage, validates thresholds via scripts/check-coverage.mjs)
-- **E2E tests:** `npm run e2e` (Playwright-BDD, starts Vite internally)
-- **Lint:** `npm run lint` (Biome check via `biome check`)
-- **Format:** `npm run format` (Biome auto-format via `biome check --write`)
+**Naming:**
+```typescript
+function getUserData() {}          // camelCase
+class PersistenceService {}       // PascalCase
+const MAX_RETRIES = 3;            // UPPER_SNAKE_CASE
+// Files: abschnitt-summe.js, persistence.service.ts
+```
 
-## Standards
+**Test example:**
+```typescript
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
 
-Follow these rules for all code you write:
+it('should calculate total', () => {
+  const result = calculateTotal([1, 2, 3]);
+  assert.strictEqual(result, 6);
+});
+```
 
-**Naming conventions:**
-- Functions/Methods: camelCase (`getUserData`, `calculateTotal`)
-- Classes/Components/Services: PascalCase (`Time`, `Section`, `PersistenceService`)
-- Constants: UPPER_SNAKE_CASE (`API_KEY`, `MAX_RETRIES`)
-- Filenames: kebab-case (`abschnitt-summe.js`, `persistence.service.ts`)
-
-**Code style:**
-- `.ts` files: model classes, services, and tests (Node test runner with node:test + node:assert/strict)
-- `.js` files: component factory functions (Vanilla JS, no TypeScript in components)
-- `.scss` files: styles per component, imported in `main.ts`
-- No comments in production code unless the intent is unclear
-
-**Coverage thresholds (scripts/check-coverage.mjs):**
-- Lines: ≥100% | Branches: ≥99.02% | Functions: ≥100%
-- Never lower thresholds. If coverage drops, add tests to restore it.
-- Thresholds are verified during `npm test` via `scripts/check-coverage.mjs`.
-
-**Test conventions:**
-- Spec files use `import { describe, it, beforeEach, mock } from 'node:test'`
-- Assertions use `import assert from 'node:assert/strict'`
-- Use `assert.strictEqual(a, b)` for equality (replaces `expect(a).toBe(b)`)
-- Use `assert.deepEqual(a, b)` for deep equality (replaces `expect(a).toEqual(b)`)
-- Use `assert.ok(condition)` for boolean checks (replaces `expect(a).toBeTruthy()`)
-- Use `mock.method(obj, 'method', impl)` for spies (replaces `jest.spyOn`)
-- Use `mock.restoreAll()` to clean up mocks after the test
-- For async operations with callbacks, wrap in `new Promise<void>(resolve => { ... })`
+## Coverage
+Lines ≥100% | Branches ≥99.02% | Functions ≥100%. Never lower thresholds – add tests instead. Verified via `scripts/check-coverage.mjs`.
 
 ## Boundaries
-- ✅ **Always:** Implement changes in `src/` (and in `e2e/` when needed), run relevant tests, follow existing patterns, and apply naming conventions.
-- ✅ **Always:** Component factory functions must return `{ element, update, destroy? }`.
-- ✅ **Always:** When you change behavior or logic, add or update automated tests so coverage does not decrease compared to the previous baseline. Ideally, improve coverage with each change.
-- ✅ **Always:** If coverage improves after your change, raise coverage thresholds to match the new measured coverage values.
-- ⚠️ **Ask first:** Adding new runtime dependencies, major changes to the build/test pipeline, or changes to PWA/service-worker configuration.
-- 🚫 **Never:** Commit secrets or API keys, edit files in `node_modules/`, or commit generated build artifacts (`dist/`).
+- ✅ **Always:** Changes in `src/` (+ `e2e/`), run tests, follow patterns, maintain/increase coverage
+- ⚠️ **Ask first:** New dependencies, build/pipeline changes, PWA/SW changes
+- 🚫 **Never:** Commit secrets, edit `node_modules/`, commit `dist/`
 
-## Reality alignment
-- Treat everything in this `AGENTS.md` as a living contract with the repository state.
-- Before implementing changes, verify that referenced facts (for example dependency versions, scripts, file paths, and tooling commands) still match the actual project files.
-- If you detect drift between this document and the codebase, update `AGENTS.md` as part of your development workflow so it stays accurate.
+## PWA
+Service Worker generated in `scripts/build.mjs` → `dist/sw.js`. Precache with CSS content-hash. `registerSW` inline in HTML head.
+
+## Reality Alignment
+Verify referenced facts match actual project files. Update AGENTS.md if drift detected.


### PR DESCRIPTION
- Remove redundant coverage mentions
- Eliminate generic persona statements
- Compact file structure and PWA sections
- Add code snippets for naming and test conventions
- Maintain all project-specific information