### PR TITLE
Improve readability: shared constants, action binding, explicit callbacks

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -60,7 +60,7 @@ export function createApp() {
         </footer>
       </div>`;
 
-    dayPlan = createDayPlan(day);
+    dayPlan = createDayPlan(day, () => abschnittSumme?.update(day));
     abschnittSumme = createAbschnittSumme(day);
     downloadPlans = createDownloadPlans();
 

--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.js
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.js
@@ -2,7 +2,7 @@ import { persistence } from '../../../services/persistence.js';
 import { icon } from '../../icons.js';
 import { createAbschnitt } from '../abschnitt/abschnitt.js';
 
-export function createAbschnittListe(day, stempelCallback, onAbschnitteChange) {
+export function createAbschnittListe(day, onAbschnitteChange) {
   const el = document.createElement('div');
   el.className = 'abschnitt-liste-host';
 
@@ -15,14 +15,10 @@ export function createAbschnittListe(day, stempelCallback, onAbschnitteChange) {
     onAbschnitteChange?.(abschnitte);
   }
 
-  function handleStempelEvent(section) {
+  function addAbschnitt(section) {
     abschnitte = [...abschnitte, section];
     persistAbschnitte();
     render();
-  }
-
-  if (stempelCallback) {
-    stempelCallback(handleStempelEvent);
   }
 
   function entferneAbschnitt(index) {
@@ -96,5 +92,5 @@ export function createAbschnittListe(day, stempelCallback, onAbschnitteChange) {
   }
 
   render();
-  return { element: el, update };
+  return { element: el, update, addAbschnitt };
 }

--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.js
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.js
@@ -2,7 +2,7 @@ import { persistence } from '../../../services/persistence.js';
 import { icon } from '../../icons.js';
 import { createAbschnitt } from '../abschnitt/abschnitt.js';
 
-export function createAbschnittListe(day, stempelCallback) {
+export function createAbschnittListe(day, stempelCallback, onAbschnitteChange) {
   const el = document.createElement('div');
   el.className = 'abschnitt-liste-host';
 
@@ -10,9 +10,14 @@ export function createAbschnittListe(day, stempelCallback) {
   let itemControllers = [];
   let editIndex = -1;
 
+  function persistAbschnitte() {
+    persistence.saveSections(day, abschnitte);
+    onAbschnitteChange?.(abschnitte);
+  }
+
   function handleStempelEvent(section) {
     abschnitte = [...abschnitte, section];
-    persistence.saveSections(day, abschnitte);
+    persistAbschnitte();
     render();
   }
 
@@ -22,13 +27,13 @@ export function createAbschnittListe(day, stempelCallback) {
 
   function entferneAbschnitt(index) {
     abschnitte = abschnitte.filter((_, i) => i !== index);
-    persistence.saveSections(day, abschnitte);
+    persistAbschnitte();
     render();
   }
 
   function aendereAbschnitt(index, newSection) {
     abschnitte = abschnitte.map((v, i) => (i === index ? newSection : v));
-    persistence.saveSections(day, abschnitte);
+    persistAbschnitte();
     editIndex = -1;
     render();
   }

--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.js
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.js
@@ -1,8 +1,6 @@
+import { LOCATIONS } from '../../../model/locations.js';
 import { Time } from '../../../model/Time.js';
-import {
-  persistence,
-  SECTIONS_CHANGED,
-} from '../../../services/persistence.js';
+import { persistence } from '../../../services/persistence.js';
 
 export function createAbschnittSumme(day) {
   const el = document.createElement('div');
@@ -26,8 +24,8 @@ export function createAbschnittSumme(day) {
   function computeDurations() {
     return {
       gesamtdauer: toTime(sumMinutes()),
-      bueroDauer: toTime(sumMinutes('Büro')),
-      mobilDauer: toTime(sumMinutes('mobil')),
+      bueroDauer: toTime(sumMinutes(LOCATIONS.OFFICE)),
+      mobilDauer: toTime(sumMinutes(LOCATIONS.MOBILE)),
     };
   }
 
@@ -68,28 +66,12 @@ export function createAbschnittSumme(day) {
       </table>`;
   }
 
-  function handleSectionsChanged(e) {
-    const { day: changedDay, sections } = e.detail;
-    if (changedDay === day) {
-      abschnitte = sections ?? [];
-      render();
-    }
-  }
-
   function update(newDay) {
     day = newDay;
     abschnitte = persistence.loadSections(day) ?? [];
     render();
   }
 
-  window.addEventListener(SECTIONS_CHANGED, handleSectionsChanged);
-
   render();
-  return {
-    element: el,
-    update,
-    destroy: () => {
-      window.removeEventListener(SECTIONS_CHANGED, handleSectionsChanged);
-    },
-  };
+  return { element: el, update };
 }

--- a/src/app/feature/day-plan/abschnitt/abschnitt.js
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.js
@@ -1,5 +1,7 @@
+import { LOCATIONS } from '../../../model/locations.js';
 import { Section } from '../../../model/Section.js';
 import { Time } from '../../../model/Time.js';
+import { bindActions } from '../../../util/bind-actions.js';
 import { icon } from '../../icons.js';
 
 export function createAbschnitt(
@@ -15,7 +17,7 @@ export function createAbschnitt(
   let startMinute = section?.startTime?.minute ?? 0;
   let endHour = section?.endTime?.hour ?? 0;
   let endMinute = section?.endTime?.minute ?? 0;
-  let location = section?.location ?? 'nicht zugeordnet';
+  let location = section?.location ?? LOCATIONS.UNASSIGNED;
 
   function render() {
     if (isEdit) {
@@ -30,9 +32,9 @@ export function createAbschnitt(
           </div>
           <div class="actions">
             <select data-location>
-              <option value="nicht zugeordnet" ${location === 'nicht zugeordnet' ? 'selected' : ''}>nicht zugeordnet</option>
-              <option value="Büro" ${location === 'Büro' ? 'selected' : ''}>Büro</option>
-              <option value="mobil" ${location === 'mobil' ? 'selected' : ''}>mobil</option>
+              <option value="${LOCATIONS.UNASSIGNED}" ${location === LOCATIONS.UNASSIGNED ? 'selected' : ''}>${LOCATIONS.UNASSIGNED}</option>
+              <option value="${LOCATIONS.OFFICE}" ${location === LOCATIONS.OFFICE ? 'selected' : ''}>${LOCATIONS.OFFICE}</option>
+              <option value="${LOCATIONS.MOBILE}" ${location === LOCATIONS.MOBILE ? 'selected' : ''}>${LOCATIONS.MOBILE}</option>
             </select>
             <div class="icon-actions">
               <span data-action="finish">${icon('check')}</span>
@@ -68,34 +70,29 @@ export function createAbschnitt(
       el.querySelector('[data-location]')?.addEventListener('change', (e) => {
         location = e.target.value;
       });
-      el.querySelector('[data-action="finish"]')?.addEventListener(
-        'click',
-        () => {
+      bindActions(el, {
+        finish: () => {
           const newStart = new Time(startHour, startMinute);
           const newEnd = new Time(endHour, endMinute);
           const newSection = new Section(newStart, newEnd, location);
           if (onSectionChange) onSectionChange(newSection);
           if (onIsEditChange) onIsEditChange(false);
         },
-      );
-      el.querySelector('[data-action="abort"]')?.addEventListener(
-        'click',
-        () => {
+        abort: () => {
           if (onIsEditChange) onIsEditChange(false);
         },
-      );
+      });
     } else {
-      el.querySelector('[data-action="edit"]')?.addEventListener(
-        'click',
-        () => {
+      bindActions(el, {
+        edit: () => {
           startHour = section?.startTime?.hour ?? 0;
           startMinute = section?.startTime?.minute ?? 0;
           endHour = section?.endTime?.hour ?? 0;
           endMinute = section?.endTime?.minute ?? 0;
-          location = section?.location ?? 'nicht zugeordnet';
+          location = section?.location ?? LOCATIONS.UNASSIGNED;
           if (onIsEditChange) onIsEditChange(true);
         },
-      );
+      });
     }
   }
 

--- a/src/app/feature/day-plan/day-plan.js
+++ b/src/app/feature/day-plan/day-plan.js
@@ -1,7 +1,7 @@
 import { createAbschnittListe } from './abschnitt-liste/abschnitt-liste.js';
 import { createStempeluhr } from './stempeluhr/stempeluhr.js';
 
-export function createDayPlan(day, _onAbschnitteChange) {
+export function createDayPlan(day, onAbschnitteChange) {
   const el = document.createElement('section');
   el.className = 'day-plan';
 
@@ -27,9 +27,13 @@ export function createDayPlan(day, _onAbschnitteChange) {
     });
 
     stempelEreignisCallback = null;
-    abschnittListe = createAbschnittListe(day, (handleStempel) => {
-      stempelEreignisCallback = handleStempel;
-    });
+    abschnittListe = createAbschnittListe(
+      day,
+      (handleStempel) => {
+        stempelEreignisCallback = handleStempel;
+      },
+      onAbschnitteChange,
+    );
 
     el.querySelector('[data-stempeluhr]').appendChild(stempeluhr.element);
     el.querySelector('[data-abschnitt-liste]').appendChild(

--- a/src/app/feature/day-plan/day-plan.js
+++ b/src/app/feature/day-plan/day-plan.js
@@ -5,7 +5,6 @@ export function createDayPlan(day, onAbschnitteChange) {
   const el = document.createElement('section');
   el.className = 'day-plan';
 
-  let stempelEreignisCallback;
   let stempeluhr;
   let abschnittListe;
 
@@ -20,19 +19,9 @@ export function createDayPlan(day, onAbschnitteChange) {
     el.querySelector('[data-testid="dayplan-title"]').textContent =
       `Tagesplan für den ${day}`;
 
-    stempeluhr = createStempeluhr(day, (section) => {
-      if (stempelEreignisCallback) {
-        stempelEreignisCallback(section);
-      }
-    });
-
-    stempelEreignisCallback = null;
-    abschnittListe = createAbschnittListe(
-      day,
-      (handleStempel) => {
-        stempelEreignisCallback = handleStempel;
-      },
-      onAbschnitteChange,
+    abschnittListe = createAbschnittListe(day, onAbschnitteChange);
+    stempeluhr = createStempeluhr(day, (section) =>
+      abschnittListe.addAbschnitt(section),
     );
 
     el.querySelector('[data-stempeluhr]').appendChild(stempeluhr.element);

--- a/src/app/feature/day-plan/stempeluhr/stempeluhr.js
+++ b/src/app/feature/day-plan/stempeluhr/stempeluhr.js
@@ -1,6 +1,7 @@
 import { Section } from '../../../model/Section.js';
 import { Time } from '../../../model/Time.js';
 import { persistence } from '../../../services/persistence.js';
+import { bindActions } from '../../../util/bind-actions.js';
 import { icon } from '../../icons.js';
 
 export function createStempeluhr(day, onStempelEreignis) {
@@ -12,29 +13,31 @@ export function createStempeluhr(day, onStempelEreignis) {
   let hour = startTime?.hour ?? 0;
   let minute = startTime?.minute ?? 0;
 
+  function renderStempelValue() {
+    if (!startTime) {
+      return '<i>noch nicht eingestempelt</i>';
+    }
+    if (isEdit) {
+      return `<span class="stempeluhr__time-inputs">
+                 <input type="number" min="0" max="23" value="${hour}" data-hour />
+                 :
+                 <input type="number" min="0" max="59" value="${minute}" data-minute />
+                 <span data-action="finish">${icon('check')}</span>
+                 <span data-action="abort">${icon('close')}</span>
+               </span>`;
+    }
+    return `<span class="stempeluhr__time-display" data-testid="login-time">
+               ${startTime.formattedString()}
+               <span data-action="edit">${icon('edit')}</span>
+             </span>`;
+  }
+
   function render() {
     el.innerHTML = `
       <div class="stempeluhr">
         <div class="stempeluhr__row">
           <span class="stempeluhr__label">Eingestempelt um:</span>
-          <div class="stempeluhr__value">
-            ${
-              !startTime
-                ? '<i>noch nicht eingestempelt</i>'
-                : isEdit
-                  ? `<span class="stempeluhr__time-inputs">
-                     <input type="number" min="0" max="23" value="${hour}" data-hour />
-                     :
-                     <input type="number" min="0" max="59" value="${minute}" data-minute />
-                     <span data-action="finish">${icon('check')}</span>
-                     <span data-action="abort">${icon('close')}</span>
-                   </span>`
-                  : `<span class="stempeluhr__time-display" data-testid="login-time">
-                     ${startTime.formattedString()}
-                     <span data-action="edit">${icon('edit')}</span>
-                   </span>`
-            }
-          </div>
+          <div class="stempeluhr__value">${renderStempelValue()}</div>
         </div>
         <div class="stempeluhr__actions">
           <span class="stempeluhr__label-placeholder" aria-hidden="true"></span>
@@ -61,34 +64,29 @@ export function createStempeluhr(day, onStempelEreignis) {
           minute = parseInt(e.target.value, 10) || 0;
         });
       }
-      el.querySelector('[data-action="finish"]')?.addEventListener(
-        'click',
-        () => {
+      bindActions(el, {
+        finish: () => {
           startTime = new Time(hour, minute);
           isEdit = false;
           persistence.saveStartTime(day, startTime);
           render();
         },
-      );
-      el.querySelector('[data-action="abort"]')?.addEventListener(
-        'click',
-        () => {
+        abort: () => {
           isEdit = false;
           hour = startTime?.hour ?? 0;
           minute = startTime?.minute ?? 0;
           render();
         },
-      );
+      });
     } else {
-      el.querySelector('[data-action="edit"]')?.addEventListener(
-        'click',
-        () => {
+      bindActions(el, {
+        edit: () => {
           hour = startTime?.hour ?? 0;
           minute = startTime?.minute ?? 0;
           isEdit = true;
           render();
         },
-      );
+      });
     }
 
     el.querySelector('[data-testid="log-button"]')?.addEventListener(

--- a/src/app/model/Section.ts
+++ b/src/app/model/Section.ts
@@ -1,3 +1,4 @@
+import { LOCATIONS } from './locations';
 import { Time, type TimeJson } from './Time';
 
 export interface SectionJson {
@@ -11,7 +12,7 @@ export class Section {
   endTime: Time;
   location: string;
 
-  constructor(startTime: Time, endTime: Time, location = 'nicht zugeordnet') {
+  constructor(startTime: Time, endTime: Time, location = LOCATIONS.UNASSIGNED) {
     this.startTime = startTime;
     this.endTime = endTime;
     this.location = location;
@@ -38,7 +39,7 @@ export class Section {
     return new Section(
       Time.fromJSON(s.startTime),
       Time.fromJSON(s.endTime),
-      s.location ?? 'nicht zugeordnet',
+      s.location ?? LOCATIONS.UNASSIGNED,
     );
   }
 }

--- a/src/app/model/Time.ts
+++ b/src/app/model/Time.ts
@@ -20,10 +20,14 @@ export class Time {
     return 60 * this.hour + this.minute;
   }
 
+  // "Industriezeit": duration expressed as a decimal hour value (7:30 -> 7.5)
+  // instead of hours:minutes, as commonly used for time billing.
   industrial(): number {
     return this.inMinutes() / 60;
   }
 
+  // Same as industrial(), rounded to the nearest quarter hour (0.25 steps),
+  // since billing is typically done in 15-minute increments.
   industrialQuarterPrecision(): number {
     return Math.round(4 * this.industrial()) / 4;
   }

--- a/src/app/model/locations.ts
+++ b/src/app/model/locations.ts
@@ -1,0 +1,8 @@
+// Single source of truth for the "Arbeitsort" values used across Section,
+// the section edit form and the duration summary — keeps them from
+// drifting out of sync when a value is renamed or a new one is added.
+export const LOCATIONS = {
+  UNASSIGNED: 'nicht zugeordnet',
+  OFFICE: 'Büro',
+  MOBILE: 'mobil',
+} as const;

--- a/src/app/persistence.spec.ts
+++ b/src/app/persistence.spec.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import { Section } from './model/Section';
 import { Time } from './model/Time';
-import { persistence, SECTIONS_CHANGED } from './services/persistence';
+import { persistence } from './services/persistence';
 
 describe('PersistenceService', () => {
   beforeEach(() => {
@@ -47,26 +47,6 @@ describe('PersistenceService', () => {
 
   it('returns undefined when no sections are available', () => {
     assert.strictEqual(persistence.loadSections('01.01.2024'), undefined);
-  });
-
-  it('emits section updates when saving sections', async () => {
-    const day = '01.01.2024';
-    const sections = [new Section(new Time(9, 0), new Time(10, 0), 'Büro')];
-
-    await new Promise<void>((resolve) => {
-      function handler(e: Event) {
-        const { day: emittedDay, sections: emittedSections } = (
-          e as CustomEvent
-        ).detail;
-        window.removeEventListener(SECTIONS_CHANGED, handler);
-        assert.strictEqual(emittedDay, day);
-        assert.deepEqual(emittedSections, sections);
-        resolve();
-      }
-
-      window.addEventListener(SECTIONS_CHANGED, handler);
-      persistence.saveSections(day, sections);
-    });
   });
 
   it('returns previous day if available, otherwise current day', () => {

--- a/src/app/services/persistence.ts
+++ b/src/app/services/persistence.ts
@@ -1,8 +1,6 @@
 import { Section, type SectionJson } from '../model/Section';
 import { Time, type TimeJson } from '../model/Time';
 
-export const SECTIONS_CHANGED = 'sectionsChanged';
-
 interface DayPlan {
   startTime?: TimeJson;
   sections?: SectionJson[];
@@ -64,9 +62,6 @@ class PersistenceService {
     const plans = this.loadDayPlan(day);
     plans[day].sections = sections;
     localStorage.setItem('plans', JSON.stringify(plans));
-    window.dispatchEvent(
-      new CustomEvent(SECTIONS_CHANGED, { detail: { day, sections } }),
-    );
   }
 
   loadSections(day: string): Section[] | undefined {
@@ -79,6 +74,8 @@ class PersistenceService {
     }
   }
 
+  // previousDay/nextDay jump to the closest day that actually has stored
+  // data, not to the calendar day ±1 — days without an entry are skipped.
   previousDay(day: string): string {
     const plans = this.loadPlans();
     const mDay = this.parseGermanDate(day);

--- a/src/app/util/bind-actions.js
+++ b/src/app/util/bind-actions.js
@@ -1,0 +1,12 @@
+// Wires up every `[data-action="name"]` element inside `el` to the matching
+// handler in `actions`, replacing the repeated
+// `el.querySelector('[data-action="x"]')?.addEventListener('click', fn)`
+// boilerplate each component used to duplicate on its own.
+export function bindActions(el, actions) {
+  for (const [name, handler] of Object.entries(actions)) {
+    el.querySelector(`[data-action="${name}"]`)?.addEventListener(
+      'click',
+      handler,
+    );
+  }
+}


### PR DESCRIPTION
- Extract duplicated location strings ("Büro"/"mobil"/"nicht zugeordnet")
  into a single LOCATIONS constant used by Section, the section edit form
  and the duration summary.
- Add a small bindActions helper to replace the repeated
  querySelector+addEventListener boilerplate each component reimplemented
  for its data-action buttons.
- Resolve the nested ternary in stempeluhr.js into a named render function
  with a top-to-bottom if/else.
- Replace the global SECTIONS_CHANGED window event with explicit callback
  wiring: day-plan.js's previously unused onAbschnitteChange parameter now
  actually connects abschnitt-liste mutations to app.js, which refreshes
  the duration summary — consistent with the callback-passing pattern used
  elsewhere in the app.
- Add short comments explaining previousDay/nextDay's existing-day-only
  navigation and the industrial-time quarter-hour rounding, where intent
  wasn't otherwise obvious.