### PR TITLE
Fix noAssignInExpressions lint errors in test-utils.ts

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
-node --import tsx --import ./test-setup.ts --experimental-test-coverage --test "$@" 2>&1 | tee .coverage.tmp
-exit_code=$?
+# dash (this script's shell) has no `pipefail`/PIPESTATUS, so `$?` after a
+# pipe would report tee's exit code, not node's — masking test failures.
+# Route node's real exit code through a temp file instead.
+status_file=$(mktemp)
+{
+  node --import tsx --import ./test-setup.ts --experimental-test-coverage --test "$@"
+  echo $? > "$status_file"
+} | tee .coverage.tmp
+test_exit_code=$(cat "$status_file")
+rm -f "$status_file"
+
 node --import tsx scripts/check-coverage.ts .coverage.tmp
-exit $exit_code
+coverage_exit_code=$?
+
+if [ "$test_exit_code" -ne 0 ]; then
+  exit "$test_exit_code"
+fi
+exit "$coverage_exit_code"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,19 +1,5 @@
 #!/bin/sh
-# dash (this script's shell) has no `pipefail`/PIPESTATUS, so `$?` after a
-# pipe would report tee's exit code, not node's — masking test failures.
-# Route node's real exit code through a temp file instead.
-status_file=$(mktemp)
-{
-  node --import tsx --import ./test-setup.ts --experimental-test-coverage --test "$@"
-  echo $? > "$status_file"
-} | tee .coverage.tmp
-test_exit_code=$(cat "$status_file")
-rm -f "$status_file"
-
+node --import tsx --import ./test-setup.ts --experimental-test-coverage --test "$@" 2>&1 | tee .coverage.tmp
+exit_code=$?
 node --import tsx scripts/check-coverage.ts .coverage.tmp
-coverage_exit_code=$?
-
-if [ "$test_exit_code" -ne 0 ]; then
-  exit "$test_exit_code"
-fi
-exit "$coverage_exit_code"
+exit $exit_code

--- a/src/app/test-utils.ts
+++ b/src/app/test-utils.ts
@@ -157,18 +157,19 @@ class FakeElement {
     const stack: FakeElement[] = [];
     let lastIndex = 0;
 
-    let match: RegExpExecArray | null;
-    while ((match = tagRegex.exec(html)) !== null) {
+    let match: RegExpExecArray | null = tagRegex.exec(html);
+    while (match !== null) {
       if (match[1]) {
         const tagName = match[1].toLowerCase();
         const attrsStr = match[2];
         const attrs: Array<[string, string]> = [];
-        let attrMatch: RegExpExecArray | null;
         const attrRe = /(\w[\w-]*)(?:=["']([^"']*)["'])?/g;
-        while ((attrMatch = attrRe.exec(attrsStr)) !== null) {
+        let attrMatch: RegExpExecArray | null = attrRe.exec(attrsStr);
+        while (attrMatch !== null) {
           if (attrMatch[1] !== undefined) {
             attrs.push([attrMatch[1], attrMatch[2] ?? '']);
           }
+          attrMatch = attrRe.exec(attrsStr);
         }
 
         const isVoid = /^(br|hr|img|input|link|meta|path)$/i.test(tagName);
@@ -198,6 +199,7 @@ class FakeElement {
         }
       }
       lastIndex = match.index + match[0].length;
+      match = tagRegex.exec(html);
     }
 
     return elements;


### PR DESCRIPTION
Move the RegExp.exec() assignment out of the while condition in
FakeElement._parseHTML for both the tag and attribute matching loops.

Fixes #517