### PR TITLE
Make lint errors a build breaker (CI and local)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
         run: ./scripts/ci-install-and-build.sh
       - name: typecheck
         run: npm run typecheck
+      - name: lint
+        run: npm run lint
       - name: run jest tests
         run: |
           npm test -- --ci

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "node --import tsx scripts/dev.ts",
     "build": "node --import tsx scripts/build.ts",
     "preview": "node --import tsx scripts/preview.ts",
-    "prebuild": "node scripts/update-version.cjs",
+    "prebuild": "npm run lint && node scripts/update-version.cjs",
     "pretest": "node scripts/update-version.cjs",
     "test": "sh scripts/run-tests.sh $(find src -name '*.spec.ts')",
     "test:watch": "node --import tsx --import ./test-setup.ts --experimental-test-coverage --watch --test $(find src -name '*.spec.ts')",


### PR DESCRIPTION
## Summary
- Add a `lint` step to the CI `build` job (`.github/workflows/build.yml`), right after `typecheck`, running `npm run lint` (Biome).
- Wire `npm run lint` into the `prebuild` hook in `package.json` so `npm run build` fails locally — for both humans and agents — whenever `biome check` reports errors, before the actual build runs.

## Context
Closes #522. Filed after #517/#518 showed that Biome lint errors were not caught anywhere: `npm run lint` wasn't run in CI, and `npm run build` didn't invoke it either.

## Test plan
- [x] `npm run build` with a clean tree — lint runs first (0 errors currently, only pre-existing warnings/infos), build completes normally.
- [x] `npm run build` with a deliberately introduced `noAssignInExpressions` error — `prebuild` fails with exit code 1 and the build script never runs.
- [x] Reviewed `.github/workflows/build.yml` diff — new `lint` step placed after `typecheck`, before the test steps.


---
_Generated by [Claude Code](https://claude.ai/code/session_01496txgYCird7vcPeiADj4S)_