### PR TITLE
Close coverage gap so run-tests.sh's exit-code fix can land

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
-node --import tsx --import ./test-setup.ts --experimental-test-coverage --test "$@" 2>&1 | tee .coverage.tmp
-exit_code=$?
+# dash (this script's shell) has no `pipefail`/PIPESTATUS, so `$?` after a
+# pipe would report tee's exit code, not node's — masking test failures.
+# Route node's real exit code through a temp file instead.
+status_file=$(mktemp)
+{
+  node --import tsx --import ./test-setup.ts --experimental-test-coverage --test "$@"
+  echo $? > "$status_file"
+} | tee .coverage.tmp
+test_exit_code=$(cat "$status_file")
+rm -f "$status_file"
+
 node --import tsx scripts/check-coverage.ts .coverage.tmp
-exit $exit_code
+coverage_exit_code=$?
+
+if [ "$test_exit_code" -ne 0 ]; then
+  exit "$test_exit_code"
+fi
+exit "$coverage_exit_code"

--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.spec.ts
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.spec.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
+import { LOCATIONS } from '../../../model/locations';
+import { Section } from '../../../model/Section';
+import { Time } from '../../../model/Time';
+import { persistence } from '../../../services/persistence';
+import { installFakeDocument } from '../../../test-utils';
+import { createAbschnittListe } from './abschnitt-liste';
+
+function fireClick(el: Element, selector: string): void {
+  const target = el.querySelector(selector) as unknown as {
+    dispatchEvent: (event: { type: string }) => void;
+  };
+  target.dispatchEvent({ type: 'click' });
+}
+
+describe('AbschnittListe', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    installFakeDocument();
+  });
+
+  it('renders nothing when there are no stored sections', () => {
+    const liste = createAbschnittListe('01.01.2024');
+
+    assert.equal(
+      liste.element.querySelector('[data-testid="section-0"]'),
+      null,
+    );
+  });
+
+  it('adds a section, persists it and notifies the change callback', () => {
+    const onAbschnitteChange = mock.fn();
+    const liste = createAbschnittListe('01.01.2024', onAbschnitteChange);
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+
+    liste.addAbschnitt(section);
+
+    assert.ok(liste.element.querySelector('[data-testid="section-0"]'));
+    assert.equal(onAbschnitteChange.mock.callCount(), 1);
+    const sections = onAbschnitteChange.mock.calls[0].arguments[0] as Section[];
+    assert.equal(sections.length, 1);
+  });
+
+  it('loads previously persisted sections for the day', () => {
+    const first = createAbschnittListe('01.01.2024');
+    first.addAbschnitt(new Section(new Time(8, 0), new Time(12, 0)));
+
+    const reloaded = createAbschnittListe('01.01.2024');
+
+    assert.ok(reloaded.element.querySelector('[data-testid="section-0"]'));
+  });
+
+  it('deletes a section and re-renders without it', () => {
+    const liste = createAbschnittListe('01.01.2024');
+    liste.addAbschnitt(new Section(new Time(8, 0), new Time(9, 0)));
+    liste.addAbschnitt(new Section(new Time(9, 0), new Time(10, 0)));
+
+    fireClick(liste.element, '[data-action="delete"]');
+
+    assert.equal(
+      liste.element.querySelector('[data-testid="section-1"]'),
+      null,
+    );
+    assert.ok(liste.element.querySelector('[data-testid="section-0"]'));
+  });
+
+  it('edits a section in place and clears edit mode afterwards', () => {
+    const onAbschnitteChange = mock.fn();
+    const liste = createAbschnittListe('01.01.2024', onAbschnitteChange);
+    liste.addAbschnitt(
+      new Section(new Time(8, 0), new Time(9, 0), LOCATIONS.OFFICE),
+    );
+
+    const editIcon = liste.element.querySelector('[data-action="edit"]');
+    assert.ok(editIcon);
+    fireClick(liste.element, '[data-action="edit"]');
+
+    assert.ok(liste.element.querySelector('[data-start-hour]'));
+
+    fireClick(liste.element, '[data-action="finish"]');
+
+    assert.equal(liste.element.querySelector('[data-start-hour]'), null);
+    assert.equal(onAbschnitteChange.mock.callCount(), 2);
+  });
+
+  it('aborting an edit leaves the section unchanged and closes edit mode', () => {
+    const liste = createAbschnittListe('01.01.2024');
+    liste.addAbschnitt(
+      new Section(new Time(8, 0), new Time(9, 0), LOCATIONS.OFFICE),
+    );
+
+    fireClick(liste.element, '[data-action="edit"]');
+    fireClick(liste.element, '[data-action="abort"]');
+
+    assert.equal(liste.element.querySelector('[data-start-hour]'), null);
+    assert.equal(persistence.loadSections('01.01.2024')?.[0].startTime.hour, 8);
+  });
+
+  it('update() switches to a different day, reloading its sections', () => {
+    const liste = createAbschnittListe('01.01.2024');
+    liste.addAbschnitt(new Section(new Time(8, 0), new Time(9, 0)));
+
+    liste.update('02.01.2024');
+
+    assert.equal(
+      liste.element.querySelector('[data-testid="section-0"]'),
+      null,
+    );
+
+    liste.addAbschnitt(new Section(new Time(10, 0), new Time(11, 0)));
+    assert.ok(liste.element.querySelector('[data-testid="section-0"]'));
+  });
+
+  it('works without an onAbschnitteChange callback', () => {
+    const liste = createAbschnittListe('01.01.2024');
+
+    assert.doesNotThrow(() => {
+      liste.addAbschnitt(new Section(new Time(8, 0), new Time(9, 0)));
+    });
+  });
+});

--- a/src/app/feature/day-plan/abschnitt/abschnitt.spec.ts
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.spec.ts
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
+import { LOCATIONS } from '../../../model/locations';
+import { Section } from '../../../model/Section';
+import { Time } from '../../../model/Time';
+import { installFakeDocument } from '../../../test-utils';
+import { createAbschnitt } from './abschnitt';
+
+interface FakeInputLike {
+  value: string;
+  dispatchEvent: (event: { type: string }) => void;
+}
+
+function fireInput(el: Element, selector: string, value: string): void {
+  const input = el.querySelector(selector) as unknown as FakeInputLike;
+  input.value = value;
+  input.dispatchEvent({ type: 'input' });
+}
+
+function fireClick(el: Element, selector: string): void {
+  const target = el.querySelector(selector) as unknown as {
+    dispatchEvent: (event: { type: string }) => void;
+  };
+  target.dispatchEvent({ type: 'click' });
+}
+
+function fireChange(el: Element, selector: string, value: string): void {
+  const select = el.querySelector(selector) as unknown as FakeInputLike;
+  select.value = value;
+  select.dispatchEvent({ type: 'change' });
+}
+
+describe('Abschnitt', () => {
+  beforeEach(() => {
+    installFakeDocument();
+  });
+
+  it('renders the formatted section and an edit action when not editing', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+    const abschnitt = createAbschnitt(section, undefined, false, undefined);
+
+    assert.ok(abschnitt.element.innerHTML.includes('08:00 - 12:00'));
+    assert.ok(abschnitt.element.querySelector('[data-action="edit"]'));
+  });
+
+  it('renders an empty string when there is no section and not editing', () => {
+    const abschnitt = createAbschnitt(undefined, undefined, false, undefined);
+
+    assert.ok(abschnitt.element.querySelector('[data-action="edit"]'));
+  });
+
+  it('switches to edit mode and resets fields from the section on edit', () => {
+    const section = new Section(
+      new Time(8, 30),
+      new Time(12, 15),
+      LOCATIONS.MOBILE,
+    );
+    let editState: boolean | undefined;
+    const abschnitt = createAbschnitt(section, undefined, false, (isEdit) => {
+      editState = isEdit;
+    });
+
+    fireClick(abschnitt.element, '[data-action="edit"]');
+
+    assert.equal(editState, true);
+  });
+
+  it('renders time inputs and the location select when editing', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+    const abschnitt = createAbschnitt(section, undefined, true, undefined);
+
+    assert.ok(abschnitt.element.querySelector('[data-start-hour]'));
+    assert.ok(abschnitt.element.querySelector('[data-start-minute]'));
+    assert.ok(abschnitt.element.querySelector('[data-end-hour]'));
+    assert.ok(abschnitt.element.querySelector('[data-end-minute]'));
+    assert.ok(abschnitt.element.querySelector('[data-location]'));
+    assert.ok(abschnitt.element.querySelector('[data-action="finish"]'));
+    assert.ok(abschnitt.element.querySelector('[data-action="abort"]'));
+  });
+
+  it('defaults time fields to 0 when there is no section while editing', () => {
+    const abschnitt = createAbschnitt(undefined, undefined, true, undefined);
+
+    assert.ok(abschnitt.element.innerHTML.includes('value="0"'));
+  });
+
+  it('tracks input changes and commits a new section on finish', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+    const onSectionChange = mock.fn();
+    const onIsEditChange = mock.fn();
+    const abschnitt = createAbschnitt(
+      section,
+      onSectionChange,
+      true,
+      onIsEditChange,
+    );
+
+    fireInput(abschnitt.element, '[data-start-hour]', '9');
+    fireInput(abschnitt.element, '[data-start-minute]', '15');
+    fireInput(abschnitt.element, '[data-end-hour]', '17');
+    fireInput(abschnitt.element, '[data-end-minute]', '45');
+    fireChange(abschnitt.element, '[data-location]', LOCATIONS.MOBILE);
+
+    fireClick(abschnitt.element, '[data-action="finish"]');
+
+    assert.equal(onSectionChange.mock.callCount(), 1);
+    const newSection = onSectionChange.mock.calls[0].arguments[0] as Section;
+    assert.equal(newSection.startTime.hour, 9);
+    assert.equal(newSection.startTime.minute, 15);
+    assert.equal(newSection.endTime.hour, 17);
+    assert.equal(newSection.endTime.minute, 45);
+    assert.equal(newSection.location, LOCATIONS.MOBILE);
+    assert.equal(onIsEditChange.mock.callCount(), 1);
+    assert.equal(onIsEditChange.mock.calls[0].arguments[0], false);
+  });
+
+  it('falls back to 0 when an input is not a number', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+    const onSectionChange = mock.fn();
+    const abschnitt = createAbschnitt(
+      section,
+      onSectionChange,
+      true,
+      undefined,
+    );
+
+    fireInput(abschnitt.element, '[data-start-hour]', 'not-a-number');
+    fireClick(abschnitt.element, '[data-action="finish"]');
+
+    const newSection = onSectionChange.mock.calls[0].arguments[0] as Section;
+    assert.equal(newSection.startTime.hour, 0);
+  });
+
+  it('discards changes and leaves edit mode on abort', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+    const onIsEditChange = mock.fn();
+    const abschnitt = createAbschnitt(section, undefined, true, onIsEditChange);
+
+    fireClick(abschnitt.element, '[data-action="abort"]');
+
+    assert.equal(onIsEditChange.mock.callCount(), 1);
+    assert.equal(onIsEditChange.mock.calls[0].arguments[0], false);
+  });
+
+  it('does nothing when finish/abort/edit callbacks are not provided', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+    const abschnitt = createAbschnitt(section, undefined, true, undefined);
+
+    assert.doesNotThrow(() => {
+      fireClick(abschnitt.element, '[data-action="finish"]');
+      fireClick(abschnitt.element, '[data-action="abort"]');
+    });
+
+    const nonEditAbschnitt = createAbschnitt(
+      section,
+      undefined,
+      false,
+      undefined,
+    );
+    assert.doesNotThrow(() => {
+      fireClick(nonEditAbschnitt.element, '[data-action="edit"]');
+    });
+  });
+
+  it('marks the mobil option as selected when the section is mobil', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.MOBILE,
+    );
+    const abschnitt = createAbschnitt(section, undefined, true, undefined);
+
+    const mobilOption = abschnitt.element.innerHTML
+      .split('\n')
+      .find((line) => line.includes(`value="${LOCATIONS.MOBILE}"`));
+
+    assert.ok(mobilOption?.includes('selected'));
+  });
+
+  it('update() re-renders reflecting the new edit state', () => {
+    const abschnitt = createAbschnitt(undefined, undefined, false, undefined);
+    const section = new Section(
+      new Time(1, 2),
+      new Time(3, 4),
+      LOCATIONS.UNASSIGNED,
+    );
+
+    assert.equal(abschnitt.element.querySelector('[data-start-hour]'), null);
+
+    abschnitt.update(section, true);
+
+    assert.ok(abschnitt.element.querySelector('[data-start-hour]'));
+
+    abschnitt.update(section, false);
+
+    assert.ok(abschnitt.element.innerHTML.includes('01:02 - 03:04'));
+  });
+});

--- a/src/app/feature/day-plan/stempeluhr/stempeluhr.spec.ts
+++ b/src/app/feature/day-plan/stempeluhr/stempeluhr.spec.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
+import type { Section } from '../../../model/Section';
+import { Time } from '../../../model/Time';
+import { persistence } from '../../../services/persistence';
+import { installFakeDocument } from '../../../test-utils';
+import { createStempeluhr } from './stempeluhr';
+
+interface FakeInputLike {
+  value: string;
+  dispatchEvent: (event: { type: string }) => void;
+}
+
+function fireInput(el: Element, selector: string, value: string): void {
+  const input = el.querySelector(selector) as unknown as FakeInputLike;
+  input.value = value;
+  input.dispatchEvent({ type: 'input' });
+}
+
+function fireClick(el: Element, selector: string): void {
+  const target = el.querySelector(selector) as unknown as {
+    dispatchEvent: (event: { type: string }) => void;
+  };
+  target.dispatchEvent({ type: 'click' });
+}
+
+describe('Stempeluhr', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    installFakeDocument();
+  });
+
+  it('shows the not-yet-clocked-in placeholder and an Einstempeln button', () => {
+    const stempeluhr = createStempeluhr('01.01.2024');
+
+    assert.ok(
+      stempeluhr.element.innerHTML.includes('noch nicht eingestempelt'),
+    );
+    assert.ok(stempeluhr.element.innerHTML.includes('Einstempeln'));
+  });
+
+  it('clocks in, persisting and displaying the start time', () => {
+    const stempeluhr = createStempeluhr('01.01.2024');
+
+    fireClick(stempeluhr.element, '[data-testid="log-button"]');
+
+    assert.ok(stempeluhr.element.innerHTML.includes('Ausstempeln'));
+    assert.ok(persistence.loadStartTime('01.01.2024') !== undefined);
+  });
+
+  it('clocks out, emitting a section and clearing the stored start time', () => {
+    persistence.saveStartTime('01.01.2024', new Time(8, 0));
+    const onStempelEreignis = mock.fn();
+    const stempeluhr = createStempeluhr('01.01.2024', onStempelEreignis);
+
+    fireClick(stempeluhr.element, '[data-testid="log-button"]');
+
+    assert.equal(onStempelEreignis.mock.callCount(), 1);
+    const section = onStempelEreignis.mock.calls[0].arguments[0] as Section;
+    assert.equal(section.startTime.hour, 8);
+    assert.equal(persistence.loadStartTime('01.01.2024'), undefined);
+  });
+
+  it('clocks out without a callback', () => {
+    persistence.saveStartTime('01.01.2024', new Time(8, 0));
+    const stempeluhr = createStempeluhr('01.01.2024');
+
+    assert.doesNotThrow(() => {
+      fireClick(stempeluhr.element, '[data-testid="log-button"]');
+    });
+  });
+
+  it('switches to edit mode and shows hour/minute inputs', () => {
+    persistence.saveStartTime('01.01.2024', new Time(8, 30));
+    const stempeluhr = createStempeluhr('01.01.2024');
+
+    fireClick(stempeluhr.element, '[data-action="edit"]');
+
+    assert.ok(stempeluhr.element.querySelector('[data-hour]'));
+    assert.ok(stempeluhr.element.querySelector('[data-minute]'));
+  });
+
+  it('tracks hour/minute input changes and commits on finish', () => {
+    persistence.saveStartTime('01.01.2024', new Time(8, 30));
+    const stempeluhr = createStempeluhr('01.01.2024');
+    fireClick(stempeluhr.element, '[data-action="edit"]');
+
+    fireInput(stempeluhr.element, '[data-hour]', '9');
+    fireInput(stempeluhr.element, '[data-minute]', '45');
+    fireClick(stempeluhr.element, '[data-action="finish"]');
+
+    const saved = persistence.loadStartTime('01.01.2024');
+    assert.equal(saved?.hour, 9);
+    assert.equal(saved?.minute, 45);
+    assert.ok(stempeluhr.element.innerHTML.includes('09:45'));
+  });
+
+  it('falls back to 0 when hour/minute input is not a number', () => {
+    persistence.saveStartTime('01.01.2024', new Time(8, 30));
+    const stempeluhr = createStempeluhr('01.01.2024');
+    fireClick(stempeluhr.element, '[data-action="edit"]');
+
+    fireInput(stempeluhr.element, '[data-hour]', 'nope');
+    fireInput(stempeluhr.element, '[data-minute]', 'nope');
+    fireClick(stempeluhr.element, '[data-action="finish"]');
+
+    const saved = persistence.loadStartTime('01.01.2024');
+    assert.equal(saved?.hour, 0);
+    assert.equal(saved?.minute, 0);
+  });
+
+  it('discards changes and restores the display on abort', () => {
+    persistence.saveStartTime('01.01.2024', new Time(8, 30));
+    const stempeluhr = createStempeluhr('01.01.2024');
+    fireClick(stempeluhr.element, '[data-action="edit"]');
+    fireInput(stempeluhr.element, '[data-hour]', '23');
+
+    fireClick(stempeluhr.element, '[data-action="abort"]');
+
+    assert.ok(stempeluhr.element.innerHTML.includes('08:30'));
+    assert.equal(persistence.loadStartTime('01.01.2024')?.hour, 8);
+  });
+
+  it('update() reloads the start time for the new day', () => {
+    persistence.saveStartTime('01.01.2024', new Time(8, 0));
+    persistence.saveStartTime('02.01.2024', new Time(9, 0));
+    const stempeluhr = createStempeluhr('01.01.2024');
+
+    stempeluhr.update('02.01.2024');
+
+    assert.ok(stempeluhr.element.innerHTML.includes('09:00'));
+  });
+
+  it('update() shows the placeholder when the new day has no start time', () => {
+    persistence.saveStartTime('01.01.2024', new Time(8, 0));
+    const stempeluhr = createStempeluhr('01.01.2024');
+
+    stempeluhr.update('03.01.2024');
+
+    assert.ok(
+      stempeluhr.element.innerHTML.includes('noch nicht eingestempelt'),
+    );
+  });
+});

--- a/src/app/test-utils.ts
+++ b/src/app/test-utils.ts
@@ -48,7 +48,8 @@ class FakeElement {
     const self = this;
     return new Proxy({} as Record<string, string>, {
       get(_, key: string) {
-        const attrName = 'data-' + key.replace(/_/g, '-').toLowerCase();
+        const attrName =
+          'data-' + key.replace(/[A-Z]/g, (c) => '-' + c.toLowerCase());
         return self._attrs.get(attrName) ?? '';
       },
     });
@@ -87,6 +88,14 @@ class FakeElement {
     handler: (...args: unknown[]) => void,
   ): void {
     this._listeners.get(event)?.delete(handler);
+  }
+
+  dispatchEvent(event: { type: string; target?: unknown }): boolean {
+    event.target ??= this;
+    for (const handler of this._listeners.get(event.type) ?? []) {
+      handler(event);
+    }
+    return true;
   }
 
   querySelector(selector: string): FakeElement | null {
@@ -140,12 +149,16 @@ class FakeElement {
   querySelectorAll(selector: string): FakeElement[] {
     const results: FakeElement[] = [];
     const attrMatch = selector.match(/^\[([\w-]+)=["']([^"']*)["']\]$/);
-    if (attrMatch) {
-      const [, attr, value] = attrMatch;
-      for (const child of this.children) {
+    const presenceMatch = selector.match(/^\[([\w-]+)\]$/);
+    for (const child of this.children) {
+      if (attrMatch) {
+        const [, attr, value] = attrMatch;
         if (child.getAttribute(attr) === value) results.push(child);
-        results.push(...child.querySelectorAll(selector));
+      } else if (presenceMatch) {
+        const [, attr] = presenceMatch;
+        if (child.hasAttribute(attr)) results.push(child);
       }
+      results.push(...child.querySelectorAll(selector));
     }
     return results;
   }


### PR DESCRIPTION
Supersedes #521 (same `run-tests.sh` fix, plus the coverage work that PR's checklist called out as a precondition for merging) and closes #516.

## Summary

#521 fixed `scripts/run-tests.sh` so `npm test` actually exits non-zero on failing tests and coverage-threshold failures (previously `$?` captured `tee`'s exit code, not `node --test`'s, and `check-coverage.ts`'s exit code was ignored entirely). That fix was left as a draft because, once exit codes were wired up correctly, it exposed a pre-existing coverage gap tracked in #516:

```
Coverage thresholds failed:
  branches: 91.13% < 92.14%
  functions: 81.46% < 87.61%
```

This PR closes that gap by adding tests for the three components #516 identified as the main contributors (`abschnitt.ts`, `stempeluhr.ts`, `abschnitt-liste.ts`), so the corrected `run-tests.sh` no longer turns `npm test` / CI red.

## Coverage test tooling fixes

Writing DOM-interaction tests for these components surfaced two bugs in the fake DOM used by `test-utils.ts` that made `abschnitt-liste`'s per-item wiring (edit/delete/finish) untestable and, in the fake-DOM environment, effectively dead:

- `dataset` only replaced underscores, never converting camelCase to kebab-case, so `cell.dataset.sectionIndex` never matched the real `data-section-index` attribute and silently returned `''`.
- `querySelectorAll` only supported `[attr="value"]` selectors, so the component's own `querySelectorAll('[data-section-index]')` (an attribute-*presence* selector) always returned an empty list — meaning the per-item `abschnitt` controllers and delete buttons were never created under test.
- Added a `dispatchEvent` implementation so tests can trigger the `input`/`change`/`click` listeners components attach via `addEventListener`.

## Result

```
Coverage OK — lines: 98.75%, branches: 93.66%, functions: 95.93%
```

All thresholds in `scripts/check-coverage.ts` are now met (previously below threshold, not lowered — new tests were added per `AGENTS.md`).

## Test plan
- [x] `npm test` passes all 61 tests
- [x] `npm test` exits `0` with coverage above all thresholds
- [x] `npm run typecheck` passes
- [x] `npm run lint` shows no new errors/warnings (2 pre-existing errors unrelated to this change, warning count reduced)

Closes #516.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KWFf341kcxS4mY1LQ7CMxw)_