### PR TITLE
Consolidate build/dev scripts and inline update-version

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,65 +1,14 @@
-import { execSync } from 'node:child_process';
 import * as crypto from 'node:crypto';
-import { mkdir, readdir, writeFile } from 'node:fs/promises';
+import { cp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as esbuild from 'esbuild';
 import * as sass from 'sass-embedded';
+import { updateVersion } from './update-version.mjs';
 
-const DIST = 'dist';
 const SRC = 'src';
 const PUBLIC = 'public';
 
-execSync('node scripts/update-version.mjs', { stdio: 'inherit' });
-
-execSync(`rm -rf ${DIST}`, { stdio: 'inherit' });
-await mkdir(`${DIST}/assets`, { recursive: true });
-
-const cssResult = sass.compile(`${SRC}/main.scss`, {
-  style: 'compressed',
-  sourceMap: false,
-  loadPaths: [SRC],
-});
-const cssContent = Buffer.from(cssResult.css);
-const cssHash = crypto
-  .createHash('sha256')
-  .update(cssContent)
-  .digest('hex')
-  .slice(0, 8);
-const cssFile = `index-${cssHash}.css`;
-await writeFile(`${DIST}/assets/${cssFile}`, cssContent);
-
-await esbuild.build({
-  entryPoints: ['src/main.ts'],
-  outdir: 'dist/assets',
-  entryNames: '[name]-[hash]',
-  format: 'esm',
-  bundle: true,
-  minify: true,
-  sourcemap: true,
-  loader: { '.ts': 'ts' },
-  plugins: [
-    {
-      name: 'ignore-scss',
-      setup(build) {
-        build.onResolve({ filter: /\.scss$/ }, (args) => ({
-          path: args.path,
-          namespace: 'scss-ignored',
-        }));
-        build.onLoad({ filter: /.*/, namespace: 'scss-ignored' }, () => ({
-          contents: '',
-          loader: 'js',
-        }));
-      },
-    },
-  ],
-});
-
-const assets = await readdir(`${DIST}/assets`);
-const jsFile = assets.find((f) => f.endsWith('.js'));
-
-execSync(`cp -r ${PUBLIC}/* ${DIST}/`, { stdio: 'inherit' });
-
-const manifest = {
+const MANIFEST = {
   name: 'Workingdiary',
   short_name: 'Workingdiary',
   description: 'Time tracking application',
@@ -76,14 +25,11 @@ const manifest = {
     { src: 'icons/icon-512x512.png', sizes: '512x512', type: 'image/png' },
   ],
 };
-await writeFile(
-  `${DIST}/manifest.webmanifest`,
-  JSON.stringify(manifest, null, 2),
-);
 
-const inlineRegisterSw = `if('serviceWorker'in navigator){window.addEventListener('load',()=>{navigator.serviceWorker.register('/sw.js',{scope:'/'})})}`;
+const registerSw = `if('serviceWorker'in navigator){window.addEventListener('load',()=>{navigator.serviceWorker.register('/sw.js',{scope:'/'})})}`;
 
-const html = `<!doctype html>
+function generateHtml(cssFile: string, jsFile: string): string {
+  return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -94,7 +40,7 @@ const html = `<!doctype html>
   <meta name="theme-color" content="#1976d2">
   <link rel="manifest" href="/manifest.webmanifest">
   <link rel="stylesheet" href="/assets/${cssFile}">
-  <script>${inlineRegisterSw}</script>
+  <script>${registerSw}</script>
 </head>
 <body>
   <app-root style="display: flex; flex-direction: column; width: 100%; height: 100%"></app-root>
@@ -102,7 +48,17 @@ const html = `<!doctype html>
   <script type="module" src="/assets/${jsFile}"></script>
 </body>
 </html>`;
-await writeFile(`${DIST}/index.html`, html);
+}
+
+function generateServiceWorker(
+  cacheKey: string,
+  precacheFiles: string[],
+): string {
+  return `const PRECACHE='${cacheKey}';const PRECACHE_URLS=${JSON.stringify(precacheFiles)};
+self.addEventListener('install',e=>{e.waitUntil(caches.open(PRECACHE).then(c=>c.addAll(PRECACHE_URLS)));self.skipWaiting()});
+self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(k=>Promise.all(k.filter(k=>k!==PRECACHE).map(k=>caches.delete(k)))));self.clientsClaim()});
+self.addEventListener('fetch',e=>{if(e.request.mode==='navigate'){e.respondWith(caches.match('/index.html').then(r=>r||fetch(e.request)))}else{e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request)))}});`;
+}
 
 async function scanDir(dir: string, prefix?: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -119,18 +75,115 @@ async function scanDir(dir: string, prefix?: string): Promise<string[]> {
   return files;
 }
 
-const precacheFiles = await scanDir(DIST);
-const urlsHash = crypto
-  .createHash('sha256')
-  .update(precacheFiles.sort().join('|'))
-  .digest('hex')
-  .slice(0, 8);
-const cacheKey = `workingdiary-v${urlsHash}`;
+export interface BuildOptions {
+  dev: boolean;
+  outDir: string;
+}
 
-const sw = `const PRECACHE='${cacheKey}';const PRECACHE_URLS=${JSON.stringify(precacheFiles)};
-self.addEventListener('install',e=>{e.waitUntil(caches.open(PRECACHE).then(c=>c.addAll(PRECACHE_URLS)));self.skipWaiting()});
-self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(k=>Promise.all(k.filter(k=>k!==PRECACHE).map(k=>caches.delete(k)))));self.clientsClaim()});
-self.addEventListener('fetch',e=>{if(e.request.mode==='navigate'){e.respondWith(caches.match('/index.html').then(r=>r||fetch(e.request)))}else{e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request)))}});`;
-await writeFile(`${DIST}/sw.js`, `${sw}\n`);
+export interface BuildResult {
+  cssFile: string;
+  jsFile: string;
+}
 
-console.log(`Build complete: ${jsFile}, ${cssFile}`);
+export async function build({
+  dev,
+  outDir,
+}: BuildOptions): Promise<BuildResult> {
+  updateVersion();
+
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(`${outDir}/assets`, { recursive: true });
+
+  const cssResult = sass.compile(
+    `${SRC}/main.scss`,
+    dev
+      ? {
+          style: 'expanded',
+          sourceMap: true,
+          sourceMapIncludeSources: true,
+          loadPaths: [SRC],
+        }
+      : { style: 'compressed', sourceMap: false, loadPaths: [SRC] },
+  );
+
+  let cssFile: string;
+  if (dev) {
+    cssFile = 'index.css';
+    await writeFile(`${outDir}/assets/${cssFile}`, cssResult.css);
+    if (cssResult.sourceMap) {
+      await writeFile(
+        `${outDir}/assets/${cssFile}.map`,
+        JSON.stringify(cssResult.sourceMap),
+      );
+    }
+  } else {
+    const cssContent = Buffer.from(cssResult.css);
+    const cssHash = crypto
+      .createHash('sha256')
+      .update(cssContent)
+      .digest('hex')
+      .slice(0, 8);
+    cssFile = `index-${cssHash}.css`;
+    await writeFile(`${outDir}/assets/${cssFile}`, cssContent);
+  }
+
+  await esbuild.build({
+    entryPoints: ['src/main.ts'],
+    outdir: `${outDir}/assets`,
+    entryNames: dev ? '[name]' : '[name]-[hash]',
+    format: 'esm',
+    bundle: true,
+    minify: !dev,
+    sourcemap: true,
+    loader: { '.ts': 'ts' },
+    plugins: [
+      {
+        name: 'ignore-scss',
+        setup(build) {
+          build.onResolve({ filter: /\.scss$/ }, (args) => ({
+            path: args.path,
+            namespace: 'scss-ignored',
+          }));
+          build.onLoad({ filter: /.*/, namespace: 'scss-ignored' }, () => ({
+            contents: '',
+            loader: 'js',
+          }));
+        },
+      },
+    ],
+  });
+
+  const assets = await readdir(`${outDir}/assets`);
+  const jsFile = assets.find((f) => f.endsWith('.js'));
+  if (!jsFile) {
+    throw new Error('esbuild did not produce a .js output file');
+  }
+
+  await cp(PUBLIC, outDir, { recursive: true });
+
+  await writeFile(
+    `${outDir}/manifest.webmanifest`,
+    JSON.stringify(MANIFEST, null, 2),
+  );
+
+  const html = generateHtml(cssFile, jsFile);
+  await writeFile(`${outDir}/index.html`, html);
+
+  const precacheFiles = await scanDir(outDir);
+  const cacheKey = dev
+    ? 'workingdiary-dev'
+    : `workingdiary-v${crypto
+        .createHash('sha256')
+        .update(precacheFiles.sort().join('|'))
+        .digest('hex')
+        .slice(0, 8)}`;
+  const sw = generateServiceWorker(cacheKey, precacheFiles);
+  await writeFile(`${outDir}/sw.js`, `${sw}\n`);
+
+  return { cssFile, jsFile };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { cssFile, jsFile } = await build({ dev: false, outDir: 'dist' });
+  console.log(`Build complete: ${jsFile}, ${cssFile}`);
+}

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,15 +1,12 @@
-import { execSync } from 'node:child_process';
 import { existsSync, statSync, type WatchEventType, watch } from 'node:fs';
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import * as http from 'node:http';
 import * as path from 'node:path';
-import * as esbuild from 'esbuild';
-import * as sass from 'sass-embedded';
+import { build as runBuild } from './build';
 
 const PORT = 5173;
 const DIST = '.dev-dist';
 const SRC = 'src';
-const PUBLIC = 'public';
 
 const clients: http.ServerResponse[] = [];
 
@@ -17,134 +14,12 @@ async function build(): Promise<void> {
   console.log('\nRebuilding...');
   const start = Date.now();
 
-  execSync('node scripts/update-version.mjs', { stdio: 'inherit' });
-
-  execSync(`rm -rf ${DIST}`, { stdio: 'inherit' });
-  await mkdir(`${DIST}/assets`, { recursive: true });
-
-  const cssResult = sass.compile(`${SRC}/main.scss`, {
-    style: 'expanded',
-    sourceMap: true,
-    sourceMapIncludeSources: true,
-    loadPaths: [SRC],
-  });
-  await writeFile(`${DIST}/assets/index.css`, cssResult.css);
-  if (cssResult.sourceMap) {
-    await writeFile(
-      `${DIST}/assets/index.css.map`,
-      JSON.stringify(cssResult.sourceMap),
-    );
-  }
-
-  await esbuild.build({
-    entryPoints: ['src/main.ts'],
-    outdir: `${DIST}/assets`,
-    entryNames: '[name]',
-    format: 'esm',
-    bundle: true,
-    minify: false,
-    sourcemap: true,
-    loader: { '.ts': 'ts' },
-    plugins: [
-      {
-        name: 'ignore-scss',
-        setup(build) {
-          build.onResolve({ filter: /\.scss$/ }, (args) => ({
-            path: args.path,
-            namespace: 'scss-ignored',
-          }));
-          build.onLoad({ filter: /.*/, namespace: 'scss-ignored' }, () => ({
-            contents: '',
-            loader: 'js',
-          }));
-        },
-      },
-    ],
-  });
-
-  execSync(`cp -r ${PUBLIC}/* ${DIST}/`, { stdio: 'inherit' });
-
-  const manifest = {
-    name: 'Workingdiary',
-    short_name: 'Workingdiary',
-    description: 'Time tracking application',
-    theme_color: '#1976d2',
-    display: 'standalone',
-    icons: [
-      { src: 'icons/icon-72x72.png', sizes: '72x72', type: 'image/png' },
-      { src: 'icons/icon-96x96.png', sizes: '96x96', type: 'image/png' },
-      { src: 'icons/icon-128x128.png', sizes: '128x128', type: 'image/png' },
-      { src: 'icons/icon-144x144.png', sizes: '144x144', type: 'image/png' },
-      { src: 'icons/icon-152x152.png', sizes: '152x152', type: 'image/png' },
-      { src: 'icons/icon-192x192.png', sizes: '192x192', type: 'image/png' },
-      { src: 'icons/icon-384x384.png', sizes: '384x384', type: 'image/png' },
-      { src: 'icons/icon-512x512.png', sizes: '512x512', type: 'image/png' },
-    ],
-  };
-  await writeFile(
-    `${DIST}/manifest.webmanifest`,
-    JSON.stringify(manifest, null, 2),
-  );
-
-  const registerSw = `if('serviceWorker'in navigator){window.addEventListener('load',()=>{navigator.serviceWorker.register('/sw.js',{scope:'/'})})}`;
-
-  const html = `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Workingdiary</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <meta name="theme-color" content="#1976d2">
-  <link rel="manifest" href="/manifest.webmanifest">
-  <link rel="stylesheet" href="/assets/index.css">
-  <script>${registerSw}</script>
-</head>
-<body>
-  <app-root style="display: flex; flex-direction: column; width: 100%; height: 100%"></app-root>
-  <noscript>Please enable JavaScript to continue using this application.</noscript>
-  <script type="module" src="/assets/main.js"></script>
-</body>
-</html>`;
-  await writeFile(`${DIST}/index.html`, html);
-
-  const precacheFiles = [
-    '/index.html',
-    '/assets/main.js',
-    '/assets/index.css',
-    ...(await scanDirFiles(`${DIST}/icons`, '/icons')),
-    '/favicon.ico',
-    '/manifest.webmanifest',
-  ];
-  const sw = `const PRECACHE='workingdiary-dev';const PRECACHE_URLS=${JSON.stringify(precacheFiles)};
-self.addEventListener('install',e=>{e.waitUntil(caches.open(PRECACHE).then(c=>c.addAll(PRECACHE_URLS)));self.skipWaiting()});
-self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(k=>Promise.all(k.filter(k=>k!==PRECACHE).map(k=>caches.delete(k)))));self.clientsClaim()});
-self.addEventListener('fetch',e=>{if(e.request.mode==='navigate'){e.respondWith(caches.match('/index.html').then(r=>r||fetch(e.request)))}else{e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request)))}});`;
-  await writeFile(`${DIST}/sw.js`, `${sw}\n`);
+  await runBuild({ dev: true, outDir: DIST });
 
   console.log(`Build complete (${Date.now() - start}ms)`);
   clients.forEach((client) => {
     client.write('data: reload\n\n');
   });
-}
-
-async function scanDirFiles(dir: string, prefix?: string): Promise<string[]> {
-  const files: string[] = [];
-  try {
-    const entries = await readdir(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      const relPath = prefix ? `${prefix}/${entry.name}` : `/${entry.name}`;
-      if (entry.isDirectory()) {
-        files.push(
-          ...(await scanDirFiles(path.join(dir, entry.name), relPath)),
-        );
-      } else {
-        files.push(relPath);
-      }
-    }
-  } catch {}
-  return files;
 }
 
 const MIME_TYPES: Record<string, string> = {

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -1,40 +1,46 @@
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 
-const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
-const version = packageJson.version;
+export function updateVersion() {
+  const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'));
+  const version = packageJson.version;
 
-const getGitValue = (command, fallback) => {
-  try {
-    return execFileSync('git', command).toString().trim();
-  } catch (e) {
-    console.log(e);
-    return fallback;
-  }
-};
+  const getGitValue = (command, fallback) => {
+    try {
+      return execFileSync('git', command).toString().trim();
+    } catch (e) {
+      console.log(e);
+      return fallback;
+    }
+  };
 
-const commitHash =
-  process.env.GIT_COMMIT_HASH ||
-  getGitValue(['rev-parse', '--short', 'HEAD'], 'unknown');
-const commitTimestamp =
-  process.env.GIT_COMMIT_TIMESTAMP ||
-  getGitValue(
-    [
-      'show',
-      '--no-patch',
-      '--date=format-local:%Y-%m-%d %H:%M:%S %z',
-      '--format=%cd',
-    ],
-    new Date().toISOString(),
-  );
+  const commitHash =
+    process.env.GIT_COMMIT_HASH ||
+    getGitValue(['rev-parse', '--short', 'HEAD'], 'unknown');
+  const commitTimestamp =
+    process.env.GIT_COMMIT_TIMESTAMP ||
+    getGitValue(
+      [
+        'show',
+        '--no-patch',
+        '--date=format-local:%Y-%m-%d %H:%M:%S %z',
+        '--format=%cd',
+      ],
+      new Date().toISOString(),
+    );
 
-const content = `export const version = '${version}';
+  const content = `export const version = '${version}';
 export const commitTimestamp = '${commitTimestamp}';
 export const commitHash = '${commitHash}';
 export const urlOfLastCommit = 'https://github.com/mohrm/workingdiary/commit/${commitHash}';
 `;
 
-console.log(`content: ${content}`);
+  console.log(`content: ${content}`);
 
-mkdirSync('./src/environments', { recursive: true });
-writeFileSync('./src/environments/version.ts', content);
+  mkdirSync('./src/environments', { recursive: true });
+  writeFileSync('./src/environments/version.ts', content);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  updateVersion();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "isolatedModules": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
-    "types": ["node"]
+    "types": ["node"],
+    "allowJs": true
   },
   "include": ["src/**/*.ts", "e2e/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
build.ts now exports a parameterized build() function (manifest, HTML
template, service worker template, directory scan) that dev.ts imports
and calls with dev-mode options, instead of duplicating that logic.
update-version.mjs exports its logic as updateVersion() so both scripts
call it in-process instead of spawning a child process via execSync,
while still working as a standalone CLI script for the npm pre-hooks.
rm -rf/cp -r shell calls are replaced with native fs.rm/fs.cp.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KdUuGBJF2SiGg8mM4sPQ47