### PR TITLE
Serialize dev watcher rebuilds to fix overlapping-build race

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -109,6 +109,32 @@ server.listen(PORT, () => {
 
 const watchedDirs = new Set<string>();
 let buildTimeout: NodeJS.Timeout | undefined;
+let buildInProgress: Promise<void> | null = null;
+let rebuildQueued = false;
+
+async function runBuildSerialized(): Promise<void> {
+  if (buildInProgress) {
+    rebuildQueued = true;
+    return;
+  }
+
+  buildInProgress = (async () => {
+    try {
+      await build();
+    } catch (err) {
+      console.error('Build failed:', err);
+    } finally {
+      buildInProgress = null;
+    }
+  })();
+
+  await buildInProgress;
+
+  if (rebuildQueued) {
+    rebuildQueued = false;
+    await runBuildSerialized();
+  }
+}
 
 async function watchDir(dir: string): Promise<void> {
   if (watchedDirs.has(dir)) return;
@@ -129,7 +155,9 @@ async function watchDir(dir: string): Promise<void> {
     const relPath = path.relative(SRC, fullPath);
     if (/\.(scss|ts|js)$/.test(relPath)) {
       clearTimeout(buildTimeout);
-      buildTimeout = setTimeout(build, 100);
+      buildTimeout = setTimeout(() => {
+        void runBuildSerialized();
+      }, 100);
     }
   };
 
@@ -145,5 +173,5 @@ async function watchDir(dir: string): Promise<void> {
   } catch {}
 }
 
-await build();
+await runBuildSerialized();
 await watchDir(SRC);


### PR DESCRIPTION
## Summary
- Fixes #528: overlapping `build()` calls in `scripts/dev.ts` raced on `.dev-dist` (`rm -rf`/`mkdir` + async writes), crashing the dev server with an unhandled `ENOENT`/`ENOTEMPTY` rejection when the 100ms debounce didn't cover several change events in quick succession (e.g. an editor doing multiple writes, or a `git checkout` touching a watched file).
- Rebuilds are now serialized: an in-flight build promise is tracked, and any change events that arrive mid-build are coalesced into a single queued rerun instead of starting a concurrent build.
- Build errors are now caught and logged instead of causing an unhandled rejection that kills the process.

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (61 tests pass, coverage thresholds met)
- [x] Manually reproduced the issue's repro steps (rapid writes to `src/main.scss` followed by `git checkout -- src/main.scss` mid-build) against `npm run dev` — rebuilds now run one at a time ("Rebuilding..." blocks never overlap) and the dev server process stays alive throughout.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HfsWwL1BcPvXg5t7rpE3aZ)_