### PR TITLE
Löschknopf in die Abschnittskomponente verschieben

### DIFF
--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.ts
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.ts
@@ -1,7 +1,6 @@
 import type { Component } from '../../../component';
 import type { Section } from '../../../model/Section';
 import { persistence } from '../../../services/persistence';
-import { icon } from '../../icons';
 import {
   type AbschnittComponent,
   createAbschnitt,
@@ -81,17 +80,9 @@ export function createAbschnittListe(
           else editIndex = index;
           render();
         },
+        () => entferneAbschnitt(index),
       );
       cell.appendChild(controller.element);
-
-      const deleteBtn = document.createElement('span');
-      deleteBtn.setAttribute('data-action', 'delete');
-      deleteBtn.setAttribute('data-index', String(index));
-      deleteBtn.innerHTML = icon('delete');
-      deleteBtn.addEventListener('click', () => {
-        entferneAbschnitt(index);
-      });
-      cell.appendChild(deleteBtn);
 
       itemControllers.push(controller);
     });

--- a/src/app/feature/day-plan/abschnitt/abschnitt.scss
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.scss
@@ -8,8 +8,9 @@
   min-width: 0;
 }
 
-.abschnitt-host [data-action="edit"] {
+.abschnitt-actions {
   margin-left: auto;
+  @include mixins.flex-row(6px, null, center);
 }
 
 .abschnitt-edit {

--- a/src/app/feature/day-plan/abschnitt/abschnitt.spec.ts
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.spec.ts
@@ -41,14 +41,27 @@ describe('Abschnitt', () => {
       new Time(12, 0),
       LOCATIONS.OFFICE,
     );
-    const abschnitt = createAbschnitt(section, undefined, false, undefined);
+    const abschnitt = createAbschnitt(
+      section,
+      undefined,
+      false,
+      undefined,
+      undefined,
+    );
 
     assert.ok(abschnitt.element.innerHTML.includes('08:00 - 12:00'));
     assert.ok(abschnitt.element.querySelector('[data-action="edit"]'));
+    assert.ok(abschnitt.element.querySelector('[data-action="delete"]'));
   });
 
   it('renders an empty string when there is no section and not editing', () => {
-    const abschnitt = createAbschnitt(undefined, undefined, false, undefined);
+    const abschnitt = createAbschnitt(
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+    );
 
     assert.ok(abschnitt.element.querySelector('[data-action="edit"]'));
   });
@@ -60,13 +73,39 @@ describe('Abschnitt', () => {
       LOCATIONS.MOBILE,
     );
     let editState: boolean | undefined;
-    const abschnitt = createAbschnitt(section, undefined, false, (isEdit) => {
-      editState = isEdit;
-    });
+    const abschnitt = createAbschnitt(
+      section,
+      undefined,
+      false,
+      (isEdit) => {
+        editState = isEdit;
+      },
+      undefined,
+    );
 
     fireClick(abschnitt.element, '[data-action="edit"]');
 
     assert.equal(editState, true);
+  });
+
+  it('calls onDelete when the delete action is clicked while not editing', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+    const onDelete = mock.fn();
+    const abschnitt = createAbschnitt(
+      section,
+      undefined,
+      false,
+      undefined,
+      onDelete,
+    );
+
+    fireClick(abschnitt.element, '[data-action="delete"]');
+
+    assert.equal(onDelete.mock.callCount(), 1);
   });
 
   it('renders time inputs and the location select when editing', () => {
@@ -75,7 +114,13 @@ describe('Abschnitt', () => {
       new Time(12, 0),
       LOCATIONS.OFFICE,
     );
-    const abschnitt = createAbschnitt(section, undefined, true, undefined);
+    const abschnitt = createAbschnitt(
+      section,
+      undefined,
+      true,
+      undefined,
+      undefined,
+    );
 
     assert.ok(abschnitt.element.querySelector('[data-start-hour]'));
     assert.ok(abschnitt.element.querySelector('[data-start-minute]'));
@@ -84,10 +129,37 @@ describe('Abschnitt', () => {
     assert.ok(abschnitt.element.querySelector('[data-location]'));
     assert.ok(abschnitt.element.querySelector('[data-action="finish"]'));
     assert.ok(abschnitt.element.querySelector('[data-action="abort"]'));
+    assert.ok(abschnitt.element.querySelector('[data-action="delete"]'));
+  });
+
+  it('calls onDelete when the delete action is clicked while editing', () => {
+    const section = new Section(
+      new Time(8, 0),
+      new Time(12, 0),
+      LOCATIONS.OFFICE,
+    );
+    const onDelete = mock.fn();
+    const abschnitt = createAbschnitt(
+      section,
+      undefined,
+      true,
+      undefined,
+      onDelete,
+    );
+
+    fireClick(abschnitt.element, '[data-action="delete"]');
+
+    assert.equal(onDelete.mock.callCount(), 1);
   });
 
   it('defaults time fields to 0 when there is no section while editing', () => {
-    const abschnitt = createAbschnitt(undefined, undefined, true, undefined);
+    const abschnitt = createAbschnitt(
+      undefined,
+      undefined,
+      true,
+      undefined,
+      undefined,
+    );
 
     assert.ok(abschnitt.element.innerHTML.includes('value="0"'));
   });
@@ -105,6 +177,7 @@ describe('Abschnitt', () => {
       onSectionChange,
       true,
       onIsEditChange,
+      undefined,
     );
 
     fireInput(abschnitt.element, '[data-start-hour]', '9');
@@ -138,6 +211,7 @@ describe('Abschnitt', () => {
       onSectionChange,
       true,
       undefined,
+      undefined,
     );
 
     fireInput(abschnitt.element, '[data-start-hour]', 'not-a-number');
@@ -154,7 +228,13 @@ describe('Abschnitt', () => {
       LOCATIONS.OFFICE,
     );
     const onIsEditChange = mock.fn();
-    const abschnitt = createAbschnitt(section, undefined, true, onIsEditChange);
+    const abschnitt = createAbschnitt(
+      section,
+      undefined,
+      true,
+      onIsEditChange,
+      undefined,
+    );
 
     fireClick(abschnitt.element, '[data-action="abort"]');
 
@@ -168,11 +248,18 @@ describe('Abschnitt', () => {
       new Time(12, 0),
       LOCATIONS.OFFICE,
     );
-    const abschnitt = createAbschnitt(section, undefined, true, undefined);
+    const abschnitt = createAbschnitt(
+      section,
+      undefined,
+      true,
+      undefined,
+      undefined,
+    );
 
     assert.doesNotThrow(() => {
       fireClick(abschnitt.element, '[data-action="finish"]');
       fireClick(abschnitt.element, '[data-action="abort"]');
+      fireClick(abschnitt.element, '[data-action="delete"]');
     });
 
     const nonEditAbschnitt = createAbschnitt(
@@ -180,9 +267,11 @@ describe('Abschnitt', () => {
       undefined,
       false,
       undefined,
+      undefined,
     );
     assert.doesNotThrow(() => {
       fireClick(nonEditAbschnitt.element, '[data-action="edit"]');
+      fireClick(nonEditAbschnitt.element, '[data-action="delete"]');
     });
   });
 
@@ -192,7 +281,13 @@ describe('Abschnitt', () => {
       new Time(12, 0),
       LOCATIONS.MOBILE,
     );
-    const abschnitt = createAbschnitt(section, undefined, true, undefined);
+    const abschnitt = createAbschnitt(
+      section,
+      undefined,
+      true,
+      undefined,
+      undefined,
+    );
 
     const mobilOption = abschnitt.element.innerHTML
       .split('\n')
@@ -202,7 +297,13 @@ describe('Abschnitt', () => {
   });
 
   it('update() re-renders reflecting the new edit state', () => {
-    const abschnitt = createAbschnitt(undefined, undefined, false, undefined);
+    const abschnitt = createAbschnitt(
+      undefined,
+      undefined,
+      false,
+      undefined,
+      undefined,
+    );
     const section = new Section(
       new Time(1, 2),
       new Time(3, 4),

--- a/src/app/feature/day-plan/abschnitt/abschnitt.ts
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.ts
@@ -14,6 +14,7 @@ export function createAbschnitt(
   onSectionChange: ((section: Section) => void) | undefined,
   isEdit: boolean,
   onIsEditChange: ((isEdit: boolean) => void) | undefined,
+  onDelete: (() => void) | undefined,
 ): AbschnittComponent {
   const el = document.createElement('div');
   el.className = 'abschnitt-host';
@@ -44,13 +45,17 @@ export function createAbschnitt(
             <div class="icon-actions">
               <span data-action="finish">${icon('check')}</span>
               <span data-action="abort">${icon('close')}</span>
+              <span data-action="delete">${icon('delete')}</span>
             </div>
           </div>
         </div>`;
     } else {
       el.innerHTML = `
         ${section ? section.formattedString() : ''}
-        <span data-action="edit">${icon('edit')}</span>`;
+        <span class="abschnitt-actions">
+          <span data-action="edit">${icon('edit')}</span>
+          <span data-action="delete">${icon('delete')}</span>
+        </span>`;
     }
     bindEvents();
   }
@@ -97,6 +102,9 @@ export function createAbschnitt(
         abort: () => {
           if (onIsEditChange) onIsEditChange(false);
         },
+        delete: () => {
+          if (onDelete) onDelete();
+        },
       });
     } else {
       bindActions(el, {
@@ -107,6 +115,9 @@ export function createAbschnitt(
           endMinute = section?.endTime?.minute ?? 0;
           location = section?.location ?? LOCATIONS.UNASSIGNED;
           if (onIsEditChange) onIsEditChange(true);
+        },
+        delete: () => {
+          if (onDelete) onDelete();
         },
       });
     }


### PR DESCRIPTION
## Summary
- Der Löschknopf für einen Abschnitt war bisher kein Teil der `Abschnitt`-Komponente, sondern wurde von `AbschnittListe` als separates Geschwister-Element daneben eingefügt, während der Editierknopf Teil der Komponente selbst war.
- `createAbschnitt` bekommt jetzt einen optionalen `onDelete`-Callback (analog zum bestehenden `onIsEditChange`-Muster), sodass Edit- und Löschbutton konsistent von derselben Komponente gerendert werden.
- Im View-Modus stehen Edit- und Löschsymbol gemeinsam in einem neuen `.abschnitt-actions`-Wrapper, im Edit-Modus liegt der Löschbutton neben Häkchen/X im bestehenden `.icon-actions`-Bereich.
- Die eigentliche Löschlogik (`entferneAbschnitt`, Persistenz) bleibt unverändert in `AbschnittListe`.

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (alle 63 Tests grün, Coverage-Schwellen erfüllt)
- [x] Manuelle Prüfung im Browser via Playwright: Edit- und Löschsymbol erscheinen nebeneinander im View-Modus, Löschsymbol im Edit-Modus neben Häkchen/X, Löschen funktioniert weiterhin

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMySJ5CNq7e7DaAsJUHHhw)_