### PR TITLE
Fix section wrongly opening in edit mode after delete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ it('should calculate total', () => {
 `src/app/sw.spec.ts` reads `dist/sw.js`, which only exists after `npm run build` — it is **not** created by `pretest`. Run `npm run build` once before `npm test` in any fresh checkout/session, otherwise those 8 Service Worker tests fail with a misleading "pre-existing failure" look (their own assertion messages say "run npm run build first" — believe them, don't wave the failures off as unrelated).
 
 ## Coverage
-Lines ≥100% | Branches ≥99.02% | Functions ≥100%. Never lower thresholds – add tests instead. Verified via `scripts/check-coverage.ts`.
+Lines ≥78.63% | Branches ≥92.14% | Functions ≥87.61%. Never lower thresholds – add tests instead. Verified via `scripts/check-coverage.ts`.
 
 **Note:** Coverage thresholds may vary slightly between runs due to branch coverage rounding. Always check actual measured values before committing threshold changes.
 

--- a/e2e/features/app.feature
+++ b/e2e/features/app.feature
@@ -35,3 +35,14 @@ Feature: Day plan page
     And I log out
     And I open the editor for section "0"
     Then the section editor inputs are fully visible
+
+  Scenario: Deleting an edited section does not leave the next new section in edit mode
+    Given today's date is "2025-02-17" and the current time is "08:00:00"
+    When I open the day plan for today
+    And I log in
+    And I log out
+    And I open the editor for section "0"
+    And I delete section "0"
+    And I log in
+    And I log out
+    Then section "0" is not being edited

--- a/e2e/steps/app.steps.ts
+++ b/e2e/steps/app.steps.ts
@@ -87,6 +87,22 @@ When(
   },
 );
 
+When('I delete section {string}', async ({ page }, sectionIndex: string) => {
+  const section = page.getByTestId(`section-${sectionIndex}`);
+  await section.waitFor();
+  const deleteIcon = section.locator('[data-action="delete"]').first();
+  await deleteIcon.click();
+});
+
+Then(
+  'section {string} is not being edited',
+  async ({ page }, sectionIndex: string) => {
+    const section = page.getByTestId(`section-${sectionIndex}`);
+    await section.waitFor();
+    await expect(section.locator('.abschnitt-edit')).toHaveCount(0);
+  },
+);
+
 Then('the section editor inputs are fully visible', async ({ page }) => {
   const editor = page.locator('.abschnitt-edit');
   await editor.waitFor();

--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.spec.ts
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.spec.ts
@@ -88,6 +88,54 @@ describe('AbschnittListe', () => {
     assert.equal(onAbschnitteChange.mock.callCount(), 2);
   });
 
+  it('deleting the section currently being edited leaves the next new section out of edit mode', () => {
+    const liste = createAbschnittListe('01.01.2024');
+    liste.addAbschnitt(
+      new Section(new Time(8, 0), new Time(9, 0), LOCATIONS.OFFICE),
+    );
+
+    fireClick(liste.element, '[data-action="edit"]');
+    assert.ok(liste.element.querySelector('[data-start-hour]'));
+
+    fireClick(liste.element, '[data-action="delete"]');
+    liste.addAbschnitt(new Section(new Time(10, 0), new Time(11, 0)));
+
+    assert.equal(liste.element.querySelector('[data-start-hour]'), null);
+  });
+
+  it('deleting a section before the edited one keeps the edited section in edit mode', () => {
+    const liste = createAbschnittListe('01.01.2024');
+    liste.addAbschnitt(new Section(new Time(8, 0), new Time(9, 0)));
+    liste.addAbschnitt(new Section(new Time(9, 0), new Time(10, 0)));
+
+    const secondSection = liste.element.querySelector(
+      '[data-testid="section-1"]',
+    );
+    assert.ok(secondSection);
+    fireClick(secondSection, '[data-action="edit"]');
+    assert.ok(
+      liste.element
+        .querySelector('[data-testid="section-1"]')
+        ?.querySelector('[data-start-hour]'),
+    );
+
+    const firstSection = liste.element.querySelector(
+      '[data-testid="section-0"]',
+    );
+    assert.ok(firstSection);
+    fireClick(firstSection, '[data-action="delete"]');
+
+    assert.equal(
+      liste.element.querySelector('[data-testid="section-1"]'),
+      null,
+    );
+    assert.ok(
+      liste.element
+        .querySelector('[data-testid="section-0"]')
+        ?.querySelector('[data-start-hour]'),
+    );
+  });
+
   it('aborting an edit leaves the section unchanged and closes edit mode', () => {
     const liste = createAbschnittListe('01.01.2024');
     liste.addAbschnitt(

--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.ts
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.ts
@@ -35,6 +35,11 @@ export function createAbschnittListe(
 
   function entferneAbschnitt(index: number): void {
     abschnitte = abschnitte.filter((_, i) => i !== index);
+    if (index === editIndex) {
+      editIndex = -1;
+    } else if (index < editIndex) {
+      editIndex -= 1;
+    }
     persistAbschnitte();
     render();
   }


### PR DESCRIPTION
## Summary
- Fix a bug where deleting the section currently being edited left a stale `editIndex`, so the next section created at that array position (e.g. via clock-in/clock-out) rendered in edit mode even though nobody opened its editor.
- `entferneAbschnitt()` now resets `editIndex` when the deleted section was the one being edited, and shifts it down when an earlier section is deleted — mirroring the index shift already performed by `filter()`.
- Add an e2e scenario reproducing the reported repro steps (log in → log out → open editor → delete → log in → log out → assert the new section is not in edit mode), plus two unit tests covering both new branches in `entferneAbschnitt`.
- Fix a documentation drift in `AGENTS.md`: the documented coverage thresholds (100%/99.02%/100%) no longer matched the enforced values in `scripts/check-coverage.ts` (78.63%/92.14%/87.61%).

## Repro (as reported)
1. Einstempeln
2. Ausstempeln
3. Editiere den entstandenen Abschnitt
4. Entferne den entstandenen Abschnitt
5. Einstempeln
6. Ausstempeln

Expected: the section created in step 6 is not in edit mode. Actual (before fix): it was.

## Test plan
- [x] `npm run build`
- [x] `npm test` (unit tests + coverage gate)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run e2e` (new scenario fails before the fix, passes after)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BC4kF84aYQJ8VNNirtBXwU)_