### PR TITLE
Verbiete Namespace-Imports (import * as x) per Lint-Regel

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,6 +22,9 @@
       "style": {
         "noNonNullAssertion": "off",
         "noCommonJs": "error"
+      },
+      "performance": {
+        "noNamespaceImport": "error"
       }
     }
   },

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,8 +1,8 @@
-import * as crypto from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { cp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
-import * as path from 'node:path';
-import * as esbuild from 'esbuild';
-import * as sass from 'sass-embedded';
+import { join } from 'node:path';
+import { build as esbuildBuild } from 'esbuild';
+import { compile as sassCompile } from 'sass-embedded';
 import { updateVersion } from './update-version.mjs';
 
 const SRC = 'src';
@@ -64,7 +64,7 @@ async function scanDir(dir: string, prefix?: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
   const files: string[] = [];
   for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
+    const fullPath = join(dir, entry.name);
     const relPath = prefix ? `${prefix}/${entry.name}` : `/${entry.name}`;
     if (entry.isDirectory()) {
       files.push(...(await scanDir(fullPath, relPath)));
@@ -94,7 +94,7 @@ export async function build({
   await rm(outDir, { recursive: true, force: true });
   await mkdir(`${outDir}/assets`, { recursive: true });
 
-  const cssResult = sass.compile(
+  const cssResult = sassCompile(
     `${SRC}/main.scss`,
     dev
       ? {
@@ -118,8 +118,7 @@ export async function build({
     }
   } else {
     const cssContent = Buffer.from(cssResult.css);
-    const cssHash = crypto
-      .createHash('sha256')
+    const cssHash = createHash('sha256')
       .update(cssContent)
       .digest('hex')
       .slice(0, 8);
@@ -127,7 +126,7 @@ export async function build({
     await writeFile(`${outDir}/assets/${cssFile}`, cssContent);
   }
 
-  await esbuild.build({
+  await esbuildBuild({
     entryPoints: ['src/main.ts'],
     outdir: `${outDir}/assets`,
     entryNames: dev ? '[name]' : '[name]-[hash]',
@@ -172,8 +171,7 @@ export async function build({
   const precacheFiles = await scanDir(outDir);
   const cacheKey = dev
     ? 'workingdiary-dev'
-    : `workingdiary-v${crypto
-        .createHash('sha256')
+    : `workingdiary-v${createHash('sha256')
         .update(precacheFiles.sort().join('|'))
         .digest('hex')
         .slice(0, 8)}`;

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,14 +1,18 @@
 import { existsSync, statSync, type WatchEventType, watch } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
-import * as http from 'node:http';
-import * as path from 'node:path';
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+import { extname, join, relative, resolve, sep } from 'node:path';
 import { build as runBuild } from './build';
 
 const PORT = 5173;
 const DIST = '.dev-dist';
 const SRC = 'src';
 
-const clients: http.ServerResponse[] = [];
+const clients: ServerResponse[] = [];
 
 async function build(): Promise<void> {
   console.log('\nRebuilding...');
@@ -33,74 +37,72 @@ const MIME_TYPES: Record<string, string> = {
   '.map': 'application/json',
 };
 
-const server = http.createServer(
-  (req: http.IncomingMessage, res: http.ServerResponse) => {
-    if (req.url === '/__reload') {
-      res.writeHead(200, {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        Connection: 'keep-alive',
+const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+  if (req.url === '/__reload') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+    clients.push(res);
+    req.on('close', () => {
+      const idx = clients.indexOf(res);
+      if (idx >= 0) clients.splice(idx, 1);
+    });
+    return;
+  }
+
+  const reqUrl = req.url;
+  if (!reqUrl) {
+    res.writeHead(400);
+    res.end('Bad Request');
+    return;
+  }
+  const url = reqUrl === '/' ? '/index.html' : reqUrl;
+  if (url.includes('..')) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+  const DIST_RESOLVED = resolve(DIST) + sep;
+  const filePath = resolve(DIST + url);
+  if (!filePath.startsWith(DIST_RESOLVED)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  try {
+    if (!existsSync(filePath)) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const content = readFile(filePath);
+    const ext = extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+
+    if (ext === '.html') {
+      content.then((buf) => {
+        const htmlContent = buf.toString();
+        const injected = htmlContent.replace(
+          '</body>',
+          '<script>new EventSource("/__reload").onmessage=()=>location.reload()</script></body>',
+        );
+        res.writeHead(200, { 'Content-Type': contentType });
+        res.end(injected);
       });
-      clients.push(res);
-      req.on('close', () => {
-        const idx = clients.indexOf(res);
-        if (idx >= 0) clients.splice(idx, 1);
+    } else {
+      content.then((buf) => {
+        res.writeHead(200, { 'Content-Type': contentType });
+        res.end(buf);
       });
-      return;
     }
-
-    const reqUrl = req.url;
-    if (!reqUrl) {
-      res.writeHead(400);
-      res.end('Bad Request');
-      return;
-    }
-    const url = reqUrl === '/' ? '/index.html' : reqUrl;
-    if (url.includes('..')) {
-      res.writeHead(403);
-      res.end('Forbidden');
-      return;
-    }
-    const DIST_RESOLVED = path.resolve(DIST) + path.sep;
-    const filePath = path.resolve(DIST + url);
-    if (!filePath.startsWith(DIST_RESOLVED)) {
-      res.writeHead(403);
-      res.end('Forbidden');
-      return;
-    }
-
-    try {
-      if (!existsSync(filePath)) {
-        res.writeHead(404);
-        res.end('Not found');
-        return;
-      }
-      const content = readFile(filePath);
-      const ext = path.extname(filePath).toLowerCase();
-      const contentType = MIME_TYPES[ext] || 'application/octet-stream';
-
-      if (ext === '.html') {
-        content.then((buf) => {
-          const htmlContent = buf.toString();
-          const injected = htmlContent.replace(
-            '</body>',
-            '<script>new EventSource("/__reload").onmessage=()=>location.reload()</script></body>',
-          );
-          res.writeHead(200, { 'Content-Type': contentType });
-          res.end(injected);
-        });
-      } else {
-        content.then((buf) => {
-          res.writeHead(200, { 'Content-Type': contentType });
-          res.end(buf);
-        });
-      }
-    } catch {
-      res.writeHead(500);
-      res.end('Server error');
-    }
-  },
-);
+  } catch {
+    res.writeHead(500);
+    res.end('Server error');
+  }
+});
 
 server.listen(PORT, () => {
   console.log(`Dev server: http://localhost:${PORT}/`);
@@ -142,7 +144,7 @@ async function watchDir(dir: string): Promise<void> {
 
   const handler = (_event: WatchEventType, filename: string | null): void => {
     if (!filename) return;
-    const fullPath = path.join(dir, filename);
+    const fullPath = join(dir, filename);
     try {
       if (
         existsSync(fullPath) &&
@@ -152,7 +154,7 @@ async function watchDir(dir: string): Promise<void> {
         watchDir(fullPath);
       }
     } catch {}
-    const relPath = path.relative(SRC, fullPath);
+    const relPath = relative(SRC, fullPath);
     if (/\.(scss|ts|js)$/.test(relPath)) {
       clearTimeout(buildTimeout);
       buildTimeout = setTimeout(() => {
@@ -167,7 +169,7 @@ async function watchDir(dir: string): Promise<void> {
     const entries = await readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
       if (entry.isDirectory()) {
-        await watchDir(path.join(dir, entry.name));
+        await watchDir(join(dir, entry.name));
       }
     }
   } catch {}

--- a/scripts/preview.ts
+++ b/scripts/preview.ts
@@ -1,5 +1,9 @@
 import { readFile } from 'node:fs';
-import * as http from 'node:http';
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
 import { extname, resolve } from 'node:path';
 
 const PORT = Number(process.env.PORT) || 5173;
@@ -16,41 +20,39 @@ const MIME_TYPES: Record<string, string> = {
   '.map': 'application/json',
 };
 
-http
-  .createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
-    const reqUrl = req.url;
-    if (!reqUrl) {
-      res.writeHead(400);
-      res.end('Bad Request');
-      return;
-    }
-    const url = reqUrl === '/' ? '/index.html' : reqUrl;
-    if (url.includes('..')) {
-      res.writeHead(403);
-      res.end('Forbidden');
-      return;
-    }
-    const filePath = resolve(`dist${url}`);
+createServer((req: IncomingMessage, res: ServerResponse) => {
+  const reqUrl = req.url;
+  if (!reqUrl) {
+    res.writeHead(400);
+    res.end('Bad Request');
+    return;
+  }
+  const url = reqUrl === '/' ? '/index.html' : reqUrl;
+  if (url.includes('..')) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+  const filePath = resolve(`dist${url}`);
 
-    if (!filePath.startsWith(DIST)) {
-      res.writeHead(403);
-      res.end('Forbidden');
+  if (!filePath.startsWith(DIST)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
       return;
     }
-
-    readFile(filePath, (err, content) => {
-      if (err) {
-        res.writeHead(404);
-        res.end('Not found');
-        return;
-      }
-      const ext = extname(filePath).toLowerCase();
-      res.writeHead(200, {
-        'Content-Type': MIME_TYPES[ext] || 'application/octet-stream',
-      });
-      res.end(content);
+    const ext = extname(filePath).toLowerCase();
+    res.writeHead(200, {
+      'Content-Type': MIME_TYPES[ext] || 'application/octet-stream',
     });
-  })
-  .listen(PORT, () => {
-    console.log(`Preview server: http://localhost:${PORT}/`);
+    res.end(content);
   });
+}).listen(PORT, () => {
+  console.log(`Preview server: http://localhost:${PORT}/`);
+});


### PR DESCRIPTION
Aktiviert lint/performance/noNamespaceImport in biome.json und
stellt die verbliebenen Sternimporte in den Build-Skripten
(scripts/build.ts, dev.ts, preview.ts) auf benannte Imports um.