### PR TITLE
Fix: npm run typecheck schlägt in frischem Checkout fehl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ it('should calculate total', () => {
 ## Before Running Tests
 `src/app/sw.spec.ts` reads `dist/sw.js`, which only exists after `npm run build` — it is **not** created by `pretest`. Run `npm run build` once before `npm test` in any fresh checkout/session, otherwise those 8 Service Worker tests fail with a misleading "pre-existing failure" look (their own assertion messages say "run npm run build first" — believe them, don't wave the failures off as unrelated).
 
+`src/environments/version.ts` is generated (gitignored, not checked in) and is imported by `src/app/services/version.ts` / `src/app/version.service.spec.ts`. `npm run typecheck` regenerates it itself via a `pretypecheck` hook (`scripts/update-version.mjs`), so it works standalone in a fresh checkout without needing `npm run build` first.
+
 ## Coverage
 Lines ≥78.63% | Branches ≥92.14% | Functions ≥87.61%. Never lower thresholds – add tests instead. Verified via `scripts/check-coverage.ts`.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "sh scripts/run-tests.sh $(find src -name '*.spec.ts')",
     "test:watch": "node --import tsx --import ./test-setup.ts --experimental-test-coverage --watch --test $(find src -name '*.spec.ts')",
     "test:docker": "bash scripts/test-docker.sh",
+    "pretypecheck": "node scripts/update-version.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "biome check",
     "format": "biome check --write",


### PR DESCRIPTION
## Summary
- `npm run typecheck` schlug in einem frischen Checkout mit zwei `TS2307`-Fehlern fehl, weil `src/environments/version.ts` (gitignored, zur Build-/Test-Zeit generiert) noch nicht existierte.
- `npm test` hatte dafür bereits einen `pretest`-Hook (`node scripts/update-version.mjs`), `npm run typecheck` aber nicht.
- Ergänzt einen analogen `pretypecheck`-Hook in `package.json`, sodass `npm run typecheck` eigenständig in jedem frischen Checkout funktioniert, ohne vorherigen `npm run build`.
- `AGENTS.md` ergänzt um den Hinweis, dass `typecheck` sich die Version-Datei selbst generiert (im Gegensatz zu `npm test`, das wegen `dist/sw.js` weiterhin einen vorherigen `npm run build` braucht).

Closes #535

## Test plan
- [x] `rm -rf src/environments/version.ts` + `npm run typecheck` in frischem Zustand → läuft jetzt ohne Fehler durch (vorher: 2x `TS2307`)
- [x] `npm run build` → erfolgreich
- [x] `npm test` → 65/65 Tests grün, Coverage 98.75% Lines / 93.87% Branches / 96.04% Functions (über den AGENTS.md-Schwellen)
- [x] `npm run lint` (Teil von `prebuild`) → sauber

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5A3PCpqxasPYvAL14wnhb)_