### PR TITLE
Enable Biome noUndeclaredVariables to catch missing imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,6 +25,9 @@
       },
       "performance": {
         "noNamespaceImport": "error"
+      },
+      "correctness": {
+        "noUndeclaredVariables": "error"
       }
     }
   },


### PR DESCRIPTION
## Summary
- `correctness/noUndeclaredVariables` is not part of Biome's `recommended` preset, so identifiers used in a `.ts` file without a local declaration or import were not flagged by the linter.
- Enables the rule in `biome.json` so this class of bug is caught going forward.
- No allowlist is needed: Biome recognizes browser and Node.js globals (`window`, `document`, `localStorage`, `process`, etc.) by default.

## Investigation
A full read-through of `src/**/*.ts` found no actual missing-import bugs — every project-internal symbol was already correctly imported. The only "undeclared" identifiers were legitimate runtime globals, so this change is a preventive linter hardening rather than a bugfix.

Verified the rule actually fires by temporarily adding a file with a genuinely undeclared identifier and confirming `npm run lint` reports it, then removing that file again.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` — 65/65 tests pass, coverage 98.75% lines / 93.87% branches / 96.04% functions (above thresholds)
- [x] Confirmed the rule catches a deliberately undeclared identifier


---
_Generated by [Claude Code](https://claude.ai/code/session_012VtCLukN65Sk1YcoNMYSiG)_