### PR TITLE
Derive Arbeitsort-Teilsummen generically from LOCATIONS

### DIFF
--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.spec.ts
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.spec.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { LOCATIONS } from '../../../model/locations';
+import { Section } from '../../../model/Section';
+import { Time } from '../../../model/Time';
+import { persistence } from '../../../services/persistence';
+import { installFakeDocument } from '../../../test-utils';
+import { createAbschnittSumme } from './abschnitt-summe';
+
+describe('AbschnittSumme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    installFakeDocument();
+  });
+
+  it('renders one row per Arbeitsort with the matching subtotal, including unassigned sections', () => {
+    const day = '01.01.2024';
+    persistence.saveSections(day, [
+      new Section(new Time(8, 0), new Time(10, 0), LOCATIONS.OFFICE),
+      new Section(new Time(10, 0), new Time(11, 0), LOCATIONS.MOBILE),
+      new Section(new Time(11, 0), new Time(11, 30), LOCATIONS.UNASSIGNED),
+    ]);
+
+    const summe = createAbschnittSumme(day);
+    const html = summe.element.innerHTML;
+
+    assert.ok(html.includes(LOCATIONS.OFFICE));
+    assert.ok(html.includes('02:00'));
+    assert.ok(html.includes(LOCATIONS.MOBILE));
+    assert.ok(html.includes('01:00'));
+    assert.ok(html.includes(LOCATIONS.UNASSIGNED));
+    assert.ok(html.includes('00:30'));
+  });
+
+  it('sums the Gesamt row across all categories, including unassigned sections', () => {
+    const day = '01.01.2024';
+    persistence.saveSections(day, [
+      new Section(new Time(8, 0), new Time(10, 0), LOCATIONS.OFFICE),
+      new Section(new Time(10, 0), new Time(11, 0), LOCATIONS.MOBILE),
+      new Section(new Time(11, 0), new Time(11, 30), LOCATIONS.UNASSIGNED),
+    ]);
+
+    const summe = createAbschnittSumme(day);
+
+    assert.ok(
+      summe.element.innerHTML.includes(
+        '<td data-testid="fullduration">03:30</td>',
+      ),
+    );
+  });
+
+  it('renders zero durations when there are no sections for the day', () => {
+    const summe = createAbschnittSumme('01.01.2024');
+
+    assert.ok(
+      summe.element.innerHTML.includes(
+        '<td data-testid="fullduration">00:00</td>',
+      ),
+    );
+  });
+
+  it('update() reloads sections for the new day and re-renders the totals', () => {
+    persistence.saveSections('01.01.2024', [
+      new Section(new Time(8, 0), new Time(9, 0), LOCATIONS.OFFICE),
+    ]);
+    persistence.saveSections('02.01.2024', [
+      new Section(new Time(8, 0), new Time(11, 0), LOCATIONS.MOBILE),
+    ]);
+
+    const summe = createAbschnittSumme('01.01.2024');
+    summe.update('02.01.2024');
+
+    assert.ok(
+      summe.element.innerHTML.includes(
+        '<td data-testid="fullduration">03:00</td>',
+      ),
+    );
+  });
+});

--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.ts
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.ts
@@ -3,12 +3,6 @@ import { LOCATIONS, type Location } from '../../../model/locations';
 import { Time } from '../../../model/Time';
 import { persistence } from '../../../services/persistence';
 
-interface AbschnittDurations {
-  gesamtdauer: Time;
-  bueroDauer: Time;
-  mobilDauer: Time;
-}
-
 export interface AbschnittSummeComponent extends Component {
   update: (day: string) => void;
 }
@@ -32,21 +26,30 @@ export function createAbschnittSumme(day: string): AbschnittSummeComponent {
     return new Time(hours, remainingMinutes);
   }
 
-  function computeDurations(): AbschnittDurations {
-    return {
-      gesamtdauer: toTime(sumMinutes()),
-      bueroDauer: toTime(sumMinutes(LOCATIONS.OFFICE)),
-      mobilDauer: toTime(sumMinutes(LOCATIONS.MOBILE)),
-    };
+  function formatIndustrial(time: Time | number): string {
+    const value = typeof time === 'number' ? time : time.industrial();
+    return value.toFixed(2);
+  }
+
+  function durationRow(label: string, dauer: Time, testId?: string): string {
+    const durationAttr = testId ? ` data-testid="${testId}"` : '';
+    const industryTestId = testId ? `${testId}-industry-combined` : undefined;
+    const industryAttr = industryTestId
+      ? ` data-testid="${industryTestId}"`
+      : '';
+    return `
+          <tr>
+            <td>${label}</td>
+            <td${durationAttr}>${dauer.formattedString()}</td>
+            <td${industryAttr}>${formatIndustrial(dauer)} / ${formatIndustrial(dauer.industrialQuarterPrecision())}</td>
+          </tr>`;
   }
 
   function render() {
-    const { gesamtdauer, bueroDauer, mobilDauer } = computeDurations();
-
-    function formatIndustrial(time: Time | number): string {
-      const value = typeof time === 'number' ? time : time.industrial();
-      return value.toFixed(2);
-    }
+    const gesamtdauer = toTime(sumMinutes());
+    const locationRows = Object.values(LOCATIONS)
+      .map((location) => durationRow(location, toTime(sumMinutes(location))))
+      .join('');
 
     el.innerHTML = `
       <table class="abschnitt-summe">
@@ -57,22 +60,7 @@ export function createAbschnittSumme(day: string): AbschnittSummeComponent {
             <th class="abschnitt-summe__nowrap">Industriezeit (exakt/gerundet)</th>
           </tr>
         </thead>
-        <tbody align="center">
-          <tr>
-            <td>Büro</td>
-            <td>${bueroDauer.formattedString()}</td>
-            <td>${formatIndustrial(bueroDauer)} / ${formatIndustrial(bueroDauer.industrialQuarterPrecision())}</td>
-          </tr>
-          <tr>
-            <td>mobil</td>
-            <td>${mobilDauer.formattedString()}</td>
-            <td>${formatIndustrial(mobilDauer)} / ${formatIndustrial(mobilDauer.industrialQuarterPrecision())}</td>
-          </tr>
-          <tr>
-            <td>Gesamt</td>
-            <td data-testid="fullduration">${gesamtdauer.formattedString()}</td>
-            <td data-testid="fullduration-industry-combined">${formatIndustrial(gesamtdauer)} / ${formatIndustrial(gesamtdauer.industrialQuarterPrecision())}</td>
-          </tr>
+        <tbody align="center">${locationRows}${durationRow('Gesamt', gesamtdauer, 'fullduration')}
         </tbody>
       </table>`;
   }


### PR DESCRIPTION
abschnitt-summe.ts hardcoded subtotals for Büro/mobil only, out of
sync with the extensible LOCATIONS enum (locations.ts) that Section
and the edit form already treat generically. This silently dropped
"nicht zugeordnet" sections from the breakdown and would require a
manual code change for every new Arbeitsort. Now each row is derived
by iterating Object.values(LOCATIONS), so the summary stays in sync
automatically.

Add abschnitt-summe.spec.ts, which previously had no test coverage.