### PR TITLE
Exclude UNASSIGNED from the Arbeitsort summary, keep it extensible

### DIFF
--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.spec.ts
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.spec.ts
@@ -13,7 +13,7 @@ describe('AbschnittSumme', () => {
     installFakeDocument();
   });
 
-  it('renders one row per Arbeitsort with the matching subtotal, including unassigned sections', () => {
+  it('renders one row per work location (Büro, mobil) with the matching subtotal', () => {
     const day = '01.01.2024';
     persistence.saveSections(day, [
       new Section(new Time(8, 0), new Time(10, 0), LOCATIONS.OFFICE),
@@ -28,11 +28,20 @@ describe('AbschnittSumme', () => {
     assert.ok(html.includes('02:00'));
     assert.ok(html.includes(LOCATIONS.MOBILE));
     assert.ok(html.includes('01:00'));
-    assert.ok(html.includes(LOCATIONS.UNASSIGNED));
-    assert.ok(html.includes('00:30'));
   });
 
-  it('sums the Gesamt row across all categories, including unassigned sections', () => {
+  it('does not render a row for unassigned sections, matching the previous behaviour', () => {
+    const day = '01.01.2024';
+    persistence.saveSections(day, [
+      new Section(new Time(11, 0), new Time(11, 30), LOCATIONS.UNASSIGNED),
+    ]);
+
+    const summe = createAbschnittSumme(day);
+
+    assert.ok(!summe.element.innerHTML.includes(LOCATIONS.UNASSIGNED));
+  });
+
+  it('sums the Gesamt row across all sections, including unassigned ones', () => {
     const day = '01.01.2024';
     persistence.saveSections(day, [
       new Section(new Time(8, 0), new Time(10, 0), LOCATIONS.OFFICE),

--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.ts
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.ts
@@ -1,5 +1,5 @@
 import type { Component } from '../../../component';
-import { LOCATIONS, type Location } from '../../../model/locations';
+import { type Location, WORK_LOCATIONS } from '../../../model/locations';
 import { Time } from '../../../model/Time';
 import { persistence } from '../../../services/persistence';
 
@@ -47,9 +47,9 @@ export function createAbschnittSumme(day: string): AbschnittSummeComponent {
 
   function render() {
     const gesamtdauer = toTime(sumMinutes());
-    const locationRows = Object.values(LOCATIONS)
-      .map((location) => durationRow(location, toTime(sumMinutes(location))))
-      .join('');
+    const locationRows = WORK_LOCATIONS.map((location) =>
+      durationRow(location, toTime(sumMinutes(location))),
+    ).join('');
 
     el.innerHTML = `
       <table class="abschnitt-summe">

--- a/src/app/model/locations.ts
+++ b/src/app/model/locations.ts
@@ -8,3 +8,11 @@ export const LOCATIONS = {
 } as const;
 
 export type Location = (typeof LOCATIONS)[keyof typeof LOCATIONS];
+
+// Locations that represent an actual place of work, i.e. every LOCATIONS
+// value except the UNASSIGNED default. The duration summary breaks totals
+// down per entry here, so a new work location only needs to be added to
+// LOCATIONS to show up there too.
+export const WORK_LOCATIONS: Location[] = Object.values(LOCATIONS).filter(
+  (location) => location !== LOCATIONS.UNASSIGNED,
+);


### PR DESCRIPTION
## Summary
- Follow-up to the previously merged fix that made `abschnitt-summe.ts` derive its subtotals generically from `LOCATIONS` instead of hardcoding `Büro`/`mobil`.
- That change unintentionally added a row for `nicht zugeordnet` (`LOCATIONS.UNASSIGNED`) to the summary table — omitting it there was intentional, not an oversight.
- Introduces `WORK_LOCATIONS` in `src/app/model/locations.ts` (`LOCATIONS` minus `UNASSIGNED`) as the set the duration summary iterates over, so the breakdown stays `Büro`/`mobil`/`Gesamt` as before, while a newly added work location still shows up automatically without touching `abschnitt-summe.ts`.
- Updated `abschnitt-summe.spec.ts` to assert unassigned sections are excluded from the per-location rows but still counted in `Gesamt`.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (70 tests passing, coverage 98.85%/94.1%/96.36%, above thresholds)


---
_Generated by [Claude Code](https://claude.ai/code/session_01M9paz6grJLeWgHw7Vy397D)_