### PR TITLE
Eliminate functionless wrapper divs from the component tree

### DIFF
--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.ts
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.ts
@@ -8,8 +8,8 @@ export interface AbschnittSummeComponent extends Component {
 }
 
 export function createAbschnittSumme(day: string): AbschnittSummeComponent {
-  const el = document.createElement('div');
-  el.className = 'abschnitt-summe-host';
+  const el = document.createElement('table');
+  el.className = 'abschnitt-summe';
 
   let abschnitte = persistence.loadSections(day) ?? [];
 
@@ -52,17 +52,15 @@ export function createAbschnittSumme(day: string): AbschnittSummeComponent {
     ).join('');
 
     el.innerHTML = `
-      <table class="abschnitt-summe">
-        <thead align="center">
-          <tr>
-            <th>Arbeitsort</th>
-            <th>Gesamtdauer</th>
-            <th class="abschnitt-summe__nowrap">Industriezeit (exakt/gerundet)</th>
-          </tr>
-        </thead>
-        <tbody align="center">${locationRows}${durationRow('Gesamt', gesamtdauer, 'fullduration')}
-        </tbody>
-      </table>`;
+      <thead align="center">
+        <tr>
+          <th>Arbeitsort</th>
+          <th>Gesamtdauer</th>
+          <th class="abschnitt-summe__nowrap">Industriezeit (exakt/gerundet)</th>
+        </tr>
+      </thead>
+      <tbody align="center">${locationRows}${durationRow('Gesamt', gesamtdauer, 'fullduration')}
+      </tbody>`;
   }
 
   function update(newDay: string): void {

--- a/src/app/feature/day-plan/stempeluhr/stempeluhr.ts
+++ b/src/app/feature/day-plan/stempeluhr/stempeluhr.ts
@@ -14,7 +14,7 @@ export function createStempeluhr(
   onStempelEreignis?: (section: Section) => void,
 ): StempeluhrComponent {
   const el = document.createElement('div');
-  el.className = 'stempeluhr-host';
+  el.className = 'stempeluhr';
 
   let startTime = persistence.loadStartTime(day);
   let isEdit = false;
@@ -42,18 +42,16 @@ export function createStempeluhr(
 
   function render() {
     el.innerHTML = `
-      <div class="stempeluhr">
-        <div class="stempeluhr__row">
-          <span class="stempeluhr__label">Eingestempelt um:</span>
-          <div class="stempeluhr__value">${renderStempelValue()}</div>
-        </div>
-        <div class="stempeluhr__actions">
-          <span class="stempeluhr__label-placeholder" aria-hidden="true"></span>
-          <button class="mat-button" data-testid="log-button">
-            <span data-action>${!startTime ? icon('login') : icon('logout')}</span>
-            ${!startTime ? 'Einstempeln' : 'Ausstempeln'}
-          </button>
-        </div>
+      <div class="stempeluhr__row">
+        <span class="stempeluhr__label">Eingestempelt um:</span>
+        <div class="stempeluhr__value">${renderStempelValue()}</div>
+      </div>
+      <div class="stempeluhr__actions">
+        <span class="stempeluhr__label-placeholder" aria-hidden="true"></span>
+        <button class="mat-button" data-testid="log-button">
+          <span data-action>${!startTime ? icon('login') : icon('logout')}</span>
+          ${!startTime ? 'Einstempeln' : 'Ausstempeln'}
+        </button>
       </div>`;
     bindEvents();
   }

--- a/src/app/feature/download-plans/download-plans.ts
+++ b/src/app/feature/download-plans/download-plans.ts
@@ -2,8 +2,9 @@ import type { Component } from '../../component';
 import { type DayPlan, persistence } from '../../services/persistence';
 
 export function createDownloadPlans(): Component {
-  const el = document.createElement('div');
+  const el = document.createElement('a');
   el.className = 'download-plans';
+  el.textContent = 'Daten exportieren';
 
   function render() {
     const plans: Record<string, DayPlan> = persistence.loadPlans();
@@ -27,7 +28,8 @@ export function createDownloadPlans(): Component {
       pad(now.getSeconds());
     const filename = `dayplans_${timestamp}.json`;
 
-    el.innerHTML = `<a href="${blobUrl}" download="${filename}">Daten exportieren</a>`;
+    el.setAttribute('href', blobUrl);
+    el.setAttribute('download', filename);
   }
 
   render();


### PR DESCRIPTION
## Summary
- `stempeluhr-host`, `abschnitt-summe-host`, and the `download-plans` root div had no CSS defined anywhere in the project — they existed purely because each component factory needs to return a root `element`, not because they served any layout, styling, or semantic purpose.
- `stempeluhr.ts`: the returned root element now carries the `stempeluhr` class directly instead of wrapping a nested `<div class="stempeluhr">`.
- `abschnitt-summe.ts`: the component root is now the `<table class="abschnitt-summe">` itself instead of a `<div>` wrapping a `<table>`.
- `download-plans.ts`: the component root is now the `<a>` element itself (with `href`/`download` set via `setAttribute`) instead of a `<div>` wrapping an anchor.
- `abschnitt-liste-host` was deliberately left in place — unlike the other three, it carries real layout CSS (`display`, `height`, `min-height`) that differs from its child `.abschnitt-liste`, so it isn't a no-op wrapper.

Verified the rendered DOM tree and interactions (Einstempeln/Ausstempeln, Abschnitt-Liste, Download-Link) manually via Playwright against the dev build — behavior is unchanged, just with one fewer wrapper `<div>` per affected component instance.

Supersedes #540, which was opened on a branch whose name no longer matched its content.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (70 tests passing, coverage 98.85%/94.09%/96.36%, above thresholds)
- [x] Manual check in the browser (Playwright) of the rendered HTML tree and the stamp-in/out, section list, and download-link interactions


---
_Generated by [Claude Code](https://claude.ai/code/session_01M9paz6grJLeWgHw7Vy397D)_