### PR TITLE
Merge divs that only wrap a single div child into one element

### DIFF
--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.ts
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.ts
@@ -16,7 +16,7 @@ export function createAbschnittListe(
   onAbschnitteChange?: (sections: Section[]) => void,
 ): AbschnittListeComponent {
   const el = document.createElement('div');
-  el.className = 'abschnitt-liste-host';
+  el.className = 'abschnitt-liste-host abschnitt-liste';
 
   let abschnitte: Section[] = persistence.loadSections(day) ?? [];
   let itemControllers: AbschnittComponent[] = [];
@@ -58,22 +58,18 @@ export function createAbschnittListe(
     itemControllers = [];
 
     el.innerHTML = `
-      <div class="abschnitt-liste">
-        <ul class="abschnitt-liste__list mat-list">
-          ${abschnitte
-            .map(
-              (_abschnitt, i) => `
-            <li class="mat-list-item abschnitt-item" data-index="${i}" data-testid="section-${i}">
-              <div class="abschnitt-cell" data-section-index="${i}"></div>
-            </li>
-          `,
-            )
-            .join('')}
-        </ul>
-      </div>`;
+      <ul class="abschnitt-liste__list mat-list">
+        ${abschnitte
+          .map(
+            (_abschnitt, i) => `
+          <li class="mat-list-item abschnitt-item" data-index="${i}" data-testid="section-${i}"></li>
+        `,
+          )
+          .join('')}
+      </ul>`;
 
-    el.querySelectorAll<HTMLElement>('[data-section-index]').forEach((cell) => {
-      const index = parseInt(cell.dataset.sectionIndex!, 10);
+    el.querySelectorAll<HTMLElement>('[data-index]').forEach((li) => {
+      const index = parseInt(li.dataset.index!, 10);
       const abschnitt = abschnitte[index];
       const isEditing = index === editIndex;
       const controller = createAbschnitt(
@@ -87,7 +83,8 @@ export function createAbschnittListe(
         },
         () => entferneAbschnitt(index),
       );
-      cell.appendChild(controller.element);
+      controller.element.classList.add('abschnitt-cell');
+      li.appendChild(controller.element);
 
       itemControllers.push(controller);
     });

--- a/src/app/feature/day-plan/abschnitt/abschnitt.ts
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.ts
@@ -26,27 +26,26 @@ export function createAbschnitt(
   let location: Location = section?.location ?? LOCATIONS.UNASSIGNED;
 
   function render() {
+    el.classList.toggle('abschnitt-edit', isEdit);
     if (isEdit) {
       el.innerHTML = `
-        <div class="abschnitt-edit">
-          <div class="time-inputs">
-            <input type="number" min="0" max="23" value="${startHour}" data-start-hour />
-            <input type="number" min="0" max="59" value="${startMinute}" data-start-minute />
-            -
-            <input type="number" min="0" max="23" value="${endHour}" data-end-hour />
-            <input type="number" min="0" max="59" value="${endMinute}" data-end-minute />
-          </div>
-          <div class="actions">
-            <select data-location>
-              <option value="${LOCATIONS.UNASSIGNED}" ${location === LOCATIONS.UNASSIGNED ? 'selected' : ''}>${LOCATIONS.UNASSIGNED}</option>
-              <option value="${LOCATIONS.OFFICE}" ${location === LOCATIONS.OFFICE ? 'selected' : ''}>${LOCATIONS.OFFICE}</option>
-              <option value="${LOCATIONS.MOBILE}" ${location === LOCATIONS.MOBILE ? 'selected' : ''}>${LOCATIONS.MOBILE}</option>
-            </select>
-            <div class="icon-actions">
-              <span data-action="finish">${icon('check')}</span>
-              <span data-action="abort">${icon('close')}</span>
-              <span data-action="delete">${icon('delete')}</span>
-            </div>
+        <div class="time-inputs">
+          <input type="number" min="0" max="23" value="${startHour}" data-start-hour />
+          <input type="number" min="0" max="59" value="${startMinute}" data-start-minute />
+          -
+          <input type="number" min="0" max="23" value="${endHour}" data-end-hour />
+          <input type="number" min="0" max="59" value="${endMinute}" data-end-minute />
+        </div>
+        <div class="actions">
+          <select data-location>
+            <option value="${LOCATIONS.UNASSIGNED}" ${location === LOCATIONS.UNASSIGNED ? 'selected' : ''}>${LOCATIONS.UNASSIGNED}</option>
+            <option value="${LOCATIONS.OFFICE}" ${location === LOCATIONS.OFFICE ? 'selected' : ''}>${LOCATIONS.OFFICE}</option>
+            <option value="${LOCATIONS.MOBILE}" ${location === LOCATIONS.MOBILE ? 'selected' : ''}>${LOCATIONS.MOBILE}</option>
+          </select>
+          <div class="icon-actions">
+            <span data-action="finish">${icon('check')}</span>
+            <span data-action="abort">${icon('close')}</span>
+            <span data-action="delete">${icon('delete')}</span>
           </div>
         </div>`;
     } else {

--- a/src/app/feature/day-plan/day-plan.ts
+++ b/src/app/feature/day-plan/day-plan.ts
@@ -27,9 +27,7 @@ export function createDayPlan(
     el.innerHTML = `
       <header class="day-plan__header">
         <h1 data-testid="dayplan-title"></h1>
-      </header>
-      <div class="day-plan__clock" data-stempeluhr></div>
-      <div class="day-plan__list" data-abschnitt-liste></div>`;
+      </header>`;
 
     el.querySelector('[data-testid="dayplan-title"]')!.textContent =
       `Tagesplan für den ${day}`;
@@ -39,10 +37,11 @@ export function createDayPlan(
       abschnittListe!.addAbschnitt(section),
     );
 
-    el.querySelector('[data-stempeluhr]')!.appendChild(stempeluhr.element);
-    el.querySelector('[data-abschnitt-liste]')!.appendChild(
-      abschnittListe.element,
-    );
+    stempeluhr.element.classList.add('day-plan__clock');
+    abschnittListe.element.classList.add('day-plan__list');
+
+    el.appendChild(stempeluhr.element);
+    el.appendChild(abschnittListe.element);
   }
 
   function update(newDay: string): void {

--- a/src/app/test-utils.ts
+++ b/src/app/test-utils.ts
@@ -54,6 +54,34 @@ class FakeElement {
     });
   }
 
+  get classList(): DOMTokenList {
+    const read = (): string[] => this.className.split(/\s+/).filter(Boolean);
+    const write = (classes: string[]): void => {
+      this.className = classes.join(' ');
+    };
+    return {
+      add: (...tokens: string[]): void => {
+        const classes = new Set(read());
+        for (const token of tokens) classes.add(token);
+        write([...classes]);
+      },
+      remove: (...tokens: string[]): void => {
+        const classes = new Set(read());
+        for (const token of tokens) classes.delete(token);
+        write([...classes]);
+      },
+      toggle: (token: string, force?: boolean): boolean => {
+        const classes = new Set(read());
+        const shouldAdd = force ?? !classes.has(token);
+        if (shouldAdd) classes.add(token);
+        else classes.delete(token);
+        write([...classes]);
+        return shouldAdd;
+      },
+      contains: (token: string): boolean => read().includes(token),
+    } as unknown as DOMTokenList;
+  }
+
   setAttribute(name: string, value: string): void {
     this._attrs.set(name, value);
   }


### PR DESCRIPTION
## Summary
Principle: every component is either a plain HTML tag or a div containing further tags/components — so a div whose only child is another div is never useful, since the outer one adds a DOM node without adding layout, styling, or semantic value beyond what a single merged element already provides. This identifies and eliminates every such construct, folding the inner div's CSS classes onto the outer div and lifting its children up a level. CSS files are untouched; only class assignment and DOM nesting changed, so the visual result should be identical.

Found and fixed:
- **day-plan.ts**: the `day-plan__clock` / `day-plan__list` slot divs each wrapped the stempeluhr/abschnitt-liste component's own root div. Removed the slot divs; those classes are now added directly onto the child components' root elements.
- **abschnitt-liste.ts**: the `abschnitt-liste` div was the sole child of the `abschnitt-liste-host` root — merged into one element carrying both classes. Likewise, the per-item `abschnitt-cell` div wrapped each abschnitt component's own root — removed, with `abschnitt-cell` added directly onto that root instead.
- **abschnitt.ts**: in edit mode, the `abschnitt-edit` div was the sole child of the `abschnitt-host` root — merged so `abschnitt-edit` is toggled directly on the root instead of a nested wrapper.

Since none of the above could be expressed with the existing `FakeElement` test double (no `classList`), added minimal `classList` support (`add`/`remove`/`toggle`/`contains`) to `test-utils.ts`.

Verified manually in the browser via Playwright: rendered DOM tree is flatter (confirmed via screenshots and by dumping `innerHTML` before/after in both display and edit mode) but the app looks and behaves identically.

### Note on e2e
`npm run e2e` currently fails in this sandbox for an unrelated, pre-existing reason (missing `chrome-headless-shell-1234` binary revision) — confirmed it reproduces identically on `main`. Filed as #542 rather than fixed here. The e2e steps that touch `.abschnitt-edit` (`app.steps.ts`) were checked by hand: the class still resolves to the same (now merged) element as a descendant of the section, so behavior is unaffected.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (70 tests passing, coverage 98.96%/93.95%/95.28%, above thresholds)
- [x] Manual verification in the browser (Playwright): DOM tree dump + screenshots, display and edit mode
- [ ] `npm run e2e` — blocked by pre-existing sandbox issue #542, unrelated to this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01M9paz6grJLeWgHw7Vy397D)_