### PR TITLE
Make the Abschnitteditor row fit on one line, including on phones

### DIFF
--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.scss
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.scss
@@ -4,11 +4,13 @@
 .abschnitt-summe {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 .abschnitt-summe th,
 .abschnitt-summe td {
   padding: vars.$padding-table-responsive;
+  overflow-wrap: anywhere;
 }
 
 .abschnitt-summe__nowrap {
@@ -23,5 +25,9 @@
   .abschnitt-summe th,
   .abschnitt-summe td {
     padding: vars.$spacing-sm;
+  }
+
+  .abschnitt-summe__nowrap {
+    white-space: normal;
   }
 }

--- a/src/app/feature/day-plan/abschnitt/abschnitt.scss
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.scss
@@ -14,46 +14,52 @@
 }
 
 .abschnitt-edit {
-  @include mixins.flex-row(vars.$spacing-md, wrap, center);
+  @include mixins.flex-row(vars.$spacing-xs, wrap, center);
   padding: vars.$spacing-lg 0;
 }
 
 .abschnitt-edit .time-inputs {
-  @include mixins.flex-row(vars.$spacing-xs, nowrap, center);
+  @include mixins.flex-row(2px, nowrap, center);
 }
 
 .abschnitt-edit input[type='number'] {
-  @include mixins.form-input-compact;
+  @include mixins.form-input-compact(2.2rem);
+  -moz-appearance: textfield;
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 }
 
 .abschnitt-edit .actions {
-  @include mixins.flex-row(6px, wrap, center);
+  @include mixins.flex-row(vars.$spacing-xs, wrap, center);
 }
 
 .abschnitt-edit select {
-  @include mixins.form-select-responsive;
+  @include mixins.form-select-responsive(4rem);
+  flex-grow: 0;
+  width: 4rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .abschnitt-edit .icon-actions {
-  @include mixins.flex-row(6px, null, center, flex-start);
+  @include mixins.flex-row(2px, null, center, flex-start);
   flex: 0 0 auto;
+}
+
+.abschnitt-edit .icon-actions [data-action] {
+  padding: vars.$spacing-xs;
+}
+
+.abschnitt-edit .icon-actions svg {
+  width: 16px;
+  height: 16px;
 }
 
 .abschnitt-edit .actions mat-icon {
   cursor: pointer;
-}
-
-@include mixins.mobile {
-  .abschnitt-edit {
-    align-items: flex-start;
-  }
-
-  .abschnitt-edit .time-inputs,
-  .abschnitt-edit .actions {
-    width: 100%;
-  }
-
-  .abschnitt-edit .actions {
-    justify-content: space-between;
-  }
 }

--- a/src/app/feature/day-plan/abschnitt/abschnitt.ts
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.ts
@@ -38,7 +38,7 @@ export function createAbschnitt(
         </div>
         <div class="actions">
           <select data-location>
-            <option value="${LOCATIONS.UNASSIGNED}" ${location === LOCATIONS.UNASSIGNED ? 'selected' : ''}>${LOCATIONS.UNASSIGNED}</option>
+            <option value="${LOCATIONS.UNASSIGNED}" ${location === LOCATIONS.UNASSIGNED ? 'selected' : ''}>kein</option>
             <option value="${LOCATIONS.OFFICE}" ${location === LOCATIONS.OFFICE ? 'selected' : ''}>${LOCATIONS.OFFICE}</option>
             <option value="${LOCATIONS.MOBILE}" ${location === LOCATIONS.MOBILE ? 'selected' : ''}>${LOCATIONS.MOBILE}</option>
           </select>


### PR DESCRIPTION
The edit row (time inputs, location select, action icons) wrapped onto
two lines almost always: the recent delete-icon addition tipped its
minimum unwrapped width over what fits at normal window widths, and the
row was never sized to fit on real phone screens (only forced into an
intentional two-row stack below 480px).

Shrink the number inputs (and hide their native spinner arrows), give
the location select a fixed narrow width instead of an unbounded
content-based one, and shrink the edit-mode action icons and gaps, so
the row's minimum width drops from ~420-450px to ~300-305px. That fits
on one line from ~360px CSS viewport width upward, comfortably covering
a Fairphone 4 (~390-400px), so the mobile two-row stacking override is
no longer needed and has been removed.