### PR TITLE
Stable Abschnitteditor cell layout + e2e coverage across device spread

### DIFF
--- a/e2e/features/app.feature
+++ b/e2e/features/app.feature
@@ -46,3 +46,31 @@ Feature: Day plan page
     And I log in
     And I log out
     Then section "0" is not being edited
+
+  Scenario: Opening the section editor does not move the time, location or delete controls
+    Given today's date is "2025-02-17" and the current time is "08:00:00"
+    And the viewport is mobile
+    When I open the day plan for today
+    And I log in
+    And I log out
+    And I remember the position of section "0"'s time, location and delete controls
+    And I open the editor for section "0"
+    Then section "0"'s time, location and delete controls have not moved
+
+  Scenario: Section editor action icons are the same size as everywhere else in the app
+    Given today's date is "2025-02-17" and the current time is "08:00:00"
+    And the viewport is mobile
+    When I open the day plan for today
+    And I log in
+    And I log out
+    And I open the editor for section "0"
+    Then the section editor's action icons are 24 by 24 pixels
+
+  Scenario: The location select shows its full label without truncation
+    Given today's date is "2025-02-17" and the current time is "08:00:00"
+    And the viewport is mobile
+    When I open the day plan for today
+    And I log in
+    And I log out
+    And I open the editor for section "0"
+    Then the location select shows its full label without truncation

--- a/e2e/features/app.feature
+++ b/e2e/features/app.feature
@@ -47,9 +47,9 @@ Feature: Day plan page
     And I log out
     Then section "0" is not being edited
 
+  @stable-layout
   Scenario: Opening the section editor does not move the time, location or delete controls
     Given today's date is "2025-02-17" and the current time is "08:00:00"
-    And the viewport is mobile
     When I open the day plan for today
     And I log in
     And I log out
@@ -57,20 +57,29 @@ Feature: Day plan page
     And I open the editor for section "0"
     Then section "0"'s time, location and delete controls have not moved
 
+  @stable-layout
   Scenario: Section editor action icons are the same size as everywhere else in the app
     Given today's date is "2025-02-17" and the current time is "08:00:00"
-    And the viewport is mobile
     When I open the day plan for today
     And I log in
     And I log out
     And I open the editor for section "0"
     Then the section editor's action icons are 24 by 24 pixels
 
+  @stable-layout
   Scenario: The location select shows its full label without truncation
     Given today's date is "2025-02-17" and the current time is "08:00:00"
-    And the viewport is mobile
     When I open the day plan for today
     And I log in
     And I log out
     And I open the editor for section "0"
     Then the location select shows its full label without truncation
+
+  @stable-layout
+  Scenario: The section editor stays on a single line
+    Given today's date is "2025-02-17" and the current time is "08:00:00"
+    When I open the day plan for today
+    And I log in
+    And I log out
+    And I open the editor for section "0"
+    Then the section editor does not overflow the viewport horizontally

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,6 +1,16 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { defineBddConfig } from 'playwright-bdd';
 
+const testDir = defineBddConfig({
+  paths: ['./features'],
+  require: ['./steps/*.ts'],
+  outputDir: '../build/cucumber',
+});
+
+// Only scenarios tagged @stable-layout run on every viewport below — the
+// rest of the suite only needs to run once, at the default desktop size.
+const STABLE_LAYOUT = /@stable-layout/;
+
 const config: PlaywrightTestConfig = {
   webServer: {
     command: 'npm run dev',
@@ -13,15 +23,10 @@ const config: PlaywrightTestConfig = {
     baseURL: 'http://localhost:5173/',
     browserName: 'chromium',
     headless: true,
-    viewport: { width: 1920, height: 1080 },
     ignoreHTTPSErrors: true,
     screenshot: 'only-on-failure',
   },
-  testDir: defineBddConfig({
-    paths: ['./features'],
-    require: ['./steps/*.ts'],
-    outputDir: '../build/cucumber',
-  }),
+  testDir,
   reporter: [
     [
       'html',
@@ -30,6 +35,66 @@ const config: PlaywrightTestConfig = {
         outputFolder: '../build/e2e',
       },
     ],
+  ],
+  projects: [
+    {
+      name: 'desktop',
+      use: { viewport: { width: 1920, height: 1080 } },
+    },
+    {
+      name: 'stable-layout-360',
+      grep: STABLE_LAYOUT,
+      use: { viewport: { width: 360, height: 800 } },
+    },
+    {
+      name: 'stable-layout-375',
+      grep: STABLE_LAYOUT,
+      use: { viewport: { width: 375, height: 800 } },
+    },
+    {
+      name: 'stable-layout-393',
+      grep: STABLE_LAYOUT,
+      use: { viewport: { width: 393, height: 800 } },
+    },
+    // Real device data supplied by the user: a Fairphone 4 running Chrome
+    // Mobile on Android.
+    {
+      name: 'stable-layout-fairphone-4',
+      grep: STABLE_LAYOUT,
+      use: {
+        viewport: { width: 411, height: 756 },
+        deviceScaleFactor: 2.625,
+        isMobile: true,
+        hasTouch: true,
+        userAgent:
+          'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Mobile Safari/537.36',
+      },
+    },
+    {
+      name: 'stable-layout-430',
+      grep: STABLE_LAYOUT,
+      use: { viewport: { width: 430, height: 800 } },
+    },
+    {
+      name: 'stable-layout-600',
+      grep: STABLE_LAYOUT,
+      use: { viewport: { width: 600, height: 900 } },
+    },
+    {
+      name: 'stable-layout-768',
+      grep: STABLE_LAYOUT,
+      use: { viewport: { width: 768, height: 1024 } },
+    },
+    {
+      name: 'stable-layout-1024',
+      grep: STABLE_LAYOUT,
+      use: { viewport: { width: 1024, height: 800 } },
+    },
+    {
+      name: 'stable-layout-1280',
+      grep: STABLE_LAYOUT,
+      use: { viewport: { width: 1280, height: 800 } },
+    },
   ],
 };
 

--- a/e2e/steps/app.steps.ts
+++ b/e2e/steps/app.steps.ts
@@ -219,3 +219,18 @@ Then(
     expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
   },
 );
+
+Then(
+  'the section editor does not overflow the viewport horizontally',
+  async ({ page }) => {
+    const editor = page.locator('.abschnitt-edit');
+    await editor.waitFor();
+
+    const overflows = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth >
+        document.documentElement.clientWidth,
+    );
+    expect(overflows).toBe(false);
+  },
+);

--- a/e2e/steps/app.steps.ts
+++ b/e2e/steps/app.steps.ts
@@ -1,8 +1,33 @@
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { createBdd } from 'playwright-bdd';
 import { hasElementWithText, navigateTo } from '../page-objects/app.po';
 
 const { Given, When, Then } = createBdd();
+
+interface ControlPositions {
+  time: { x: number; y: number } | null;
+  location: { x: number; y: number } | null;
+  delete: { x: number; y: number } | null;
+}
+
+const rememberedPositions = new WeakMap<Page, ControlPositions>();
+
+async function readControlPositions(
+  page: Page,
+  sectionIndex: string,
+): Promise<ControlPositions> {
+  const section = page.getByTestId(`section-${sectionIndex}`);
+  await section.waitFor();
+  const boxOf = async (selector: string) => {
+    const box = await section.locator(selector).first().boundingBox();
+    return box ? { x: box.x, y: box.y } : null;
+  };
+  return {
+    time: await boxOf('[data-start-hour]'),
+    location: await boxOf('[data-location]'),
+    delete: await boxOf('[data-action="delete"]'),
+  };
+}
 
 Given('I open the home page', async ({ page: _page }) => {});
 
@@ -124,3 +149,73 @@ Then('the section editor inputs are fully visible', async ({ page }) => {
     expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height);
   }
 });
+
+Given(
+  "I remember the position of section {string}'s time, location and delete controls",
+  async ({ page }, sectionIndex: string) => {
+    rememberedPositions.set(
+      page,
+      await readControlPositions(page, sectionIndex),
+    );
+  },
+);
+
+Then(
+  "section {string}'s time, location and delete controls have not moved",
+  async ({ page }, sectionIndex: string) => {
+    const before = rememberedPositions.get(page);
+    if (!before) {
+      throw new Error(
+        'No remembered position — call the "I remember the position of..." step first.',
+      );
+    }
+    const after = await readControlPositions(page, sectionIndex);
+
+    for (const control of ['time', 'location', 'delete'] as const) {
+      expect(before[control], `${control} before`).not.toBeNull();
+      expect(after[control], `${control} after`).not.toBeNull();
+      expect(after[control]!.x, `${control} x`).toBeCloseTo(
+        before[control]!.x,
+        0,
+      );
+      expect(after[control]!.y, `${control} y`).toBeCloseTo(
+        before[control]!.y,
+        0,
+      );
+    }
+  },
+);
+
+Then(
+  "the section editor's action icons are 24 by 24 pixels",
+  async ({ page }) => {
+    const editor = page.locator('.abschnitt-edit');
+    await editor.waitFor();
+
+    const icons = editor.locator('.abschnitt-icon-zone svg');
+    const count = await icons.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const box = await icons.nth(i).boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.width).toBe(24);
+      expect(box!.height).toBe(24);
+    }
+  },
+);
+
+Then(
+  'the location select shows its full label without truncation',
+  async ({ page }) => {
+    const select = page.locator('.abschnitt-edit select[data-location]');
+    await select.waitFor();
+
+    const { clientWidth, scrollWidth } = await select.evaluate((el) => ({
+      clientWidth: (el as HTMLSelectElement).clientWidth,
+      scrollWidth: (el as HTMLSelectElement).scrollWidth,
+    }));
+
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+  },
+);

--- a/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.spec.ts
+++ b/src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.spec.ts
@@ -80,11 +80,11 @@ describe('AbschnittListe', () => {
     assert.ok(editIcon);
     fireClick(liste.element, '[data-action="edit"]');
 
-    assert.ok(liste.element.querySelector('[data-start-hour]'));
+    assert.ok(liste.element.querySelector('input[data-start-hour]'));
 
     fireClick(liste.element, '[data-action="finish"]');
 
-    assert.equal(liste.element.querySelector('[data-start-hour]'), null);
+    assert.equal(liste.element.querySelector('input[data-start-hour]'), null);
     assert.equal(onAbschnitteChange.mock.callCount(), 2);
   });
 
@@ -95,12 +95,12 @@ describe('AbschnittListe', () => {
     );
 
     fireClick(liste.element, '[data-action="edit"]');
-    assert.ok(liste.element.querySelector('[data-start-hour]'));
+    assert.ok(liste.element.querySelector('input[data-start-hour]'));
 
     fireClick(liste.element, '[data-action="delete"]');
     liste.addAbschnitt(new Section(new Time(10, 0), new Time(11, 0)));
 
-    assert.equal(liste.element.querySelector('[data-start-hour]'), null);
+    assert.equal(liste.element.querySelector('input[data-start-hour]'), null);
   });
 
   it('deleting a section before the edited one keeps the edited section in edit mode', () => {
@@ -116,7 +116,7 @@ describe('AbschnittListe', () => {
     assert.ok(
       liste.element
         .querySelector('[data-testid="section-1"]')
-        ?.querySelector('[data-start-hour]'),
+        ?.querySelector('input[data-start-hour]'),
     );
 
     const firstSection = liste.element.querySelector(
@@ -132,7 +132,7 @@ describe('AbschnittListe', () => {
     assert.ok(
       liste.element
         .querySelector('[data-testid="section-0"]')
-        ?.querySelector('[data-start-hour]'),
+        ?.querySelector('input[data-start-hour]'),
     );
   });
 
@@ -145,7 +145,7 @@ describe('AbschnittListe', () => {
     fireClick(liste.element, '[data-action="edit"]');
     fireClick(liste.element, '[data-action="abort"]');
 
-    assert.equal(liste.element.querySelector('[data-start-hour]'), null);
+    assert.equal(liste.element.querySelector('input[data-start-hour]'), null);
     assert.equal(persistence.loadSections('01.01.2024')?.[0].startTime.hour, 8);
   });
 

--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.scss
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.scss
@@ -13,10 +13,6 @@
   overflow-wrap: anywhere;
 }
 
-.abschnitt-summe__nowrap {
-  white-space: nowrap;
-}
-
 @include mixins.mobile {
   .abschnitt-summe {
     font-size: vars.$font-size-mobile;
@@ -25,9 +21,5 @@
   .abschnitt-summe th,
   .abschnitt-summe td {
     padding: vars.$spacing-sm;
-  }
-
-  .abschnitt-summe__nowrap {
-    white-space: normal;
   }
 }

--- a/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.ts
+++ b/src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.ts
@@ -56,7 +56,7 @@ export function createAbschnittSumme(day: string): AbschnittSummeComponent {
         <tr>
           <th>Arbeitsort</th>
           <th>Gesamtdauer</th>
-          <th class="abschnitt-summe__nowrap">Industriezeit (exakt/gerundet)</th>
+          <th>Industriezeit (exakt/gerundet)</th>
         </tr>
       </thead>
       <tbody align="center">${locationRows}${durationRow('Gesamt', gesamtdauer, 'fullduration')}

--- a/src/app/feature/day-plan/abschnitt/abschnitt.scss
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.scss
@@ -8,22 +8,42 @@
   min-width: 0;
 }
 
-.abschnitt-actions {
-  margin-left: auto;
-  @include mixins.flex-row(6px, null, center);
+// Single child of .abschnitt-host so the ambient `.abschnitt-cell { gap: 8px }`
+// (set by abschnitt-liste.ts, unrelated to this component) never leaks
+// between the cells below regardless of stylesheet cascade order.
+.abschnitt-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: vars.$spacing-xs;
+  width: 100%;
 }
 
-.abschnitt-edit {
-  @include mixins.flex-row(vars.$spacing-xs, wrap, center);
-  padding: vars.$spacing-lg 0;
+.abschnitt-time-range {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
 }
 
-.abschnitt-edit .time-inputs {
-  @include mixins.flex-row(2px, nowrap, center);
+.abschnitt-time-sep {
+  padding: 0 1px;
 }
 
-.abschnitt-edit input[type='number'] {
-  @include mixins.form-input-compact(2.2rem);
+// Shared by the view-mode <span> and the edit-mode <input> so toggling
+// between them never changes this cell's box size or position.
+.abschnitt-time-cell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 2.75rem;
+  flex-shrink: 0;
+  padding: vars.$spacing-xs vars.$spacing-sm;
+  border: 1px solid transparent;
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
   -moz-appearance: textfield;
 
   &::-webkit-inner-spin-button,
@@ -33,33 +53,58 @@
   }
 }
 
-.abschnitt-edit .actions {
-  @include mixins.flex-row(vars.$spacing-xs, wrap, center);
+input.abschnitt-time-cell {
+  border-color: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
 }
 
-.abschnitt-edit select {
-  @include mixins.form-select-responsive(4rem);
-  flex-grow: 0;
-  width: 4rem;
+// Shared by the view-mode <span> and the edit-mode <select>, same reasoning
+// as .abschnitt-time-cell above.
+.abschnitt-location-cell {
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  width: 4.5rem;
+  flex-shrink: 0;
+  padding: vars.$spacing-xs vars.$spacing-xs;
+  border: 1px solid transparent;
+  font: inherit;
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.abschnitt-edit .icon-actions {
-  @include mixins.flex-row(2px, null, center, flex-start);
+select.abschnitt-location-cell {
+  border-color: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+  appearance: none;
+  padding-right: 1.125rem;
+  background:
+    right 6px center / 8px 6px no-repeat
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 6'%3E%3Cpath d='M0 0h8L4 6z' fill='%23555'/%3E%3C/svg%3E");
+}
+
+// Reserves 3 fixed-size slots regardless of how many are filled: view mode
+// only places `edit` (slot 2) and `delete` (slot 3), leaving slot 1 empty,
+// so `delete` never moves and `edit`/`finish` share the same slot.
+.abschnitt-icon-zone {
+  display: grid;
+  grid-template-columns: repeat(3, 24px);
+  column-gap: vars.$spacing-xs;
+  align-items: center;
+  justify-items: center;
   flex: 0 0 auto;
+  margin-left: auto;
 }
 
-.abschnitt-edit .icon-actions [data-action] {
-  padding: vars.$spacing-xs;
+.abschnitt-icon-zone [data-action='abort'] {
+  grid-column: 1;
 }
 
-.abschnitt-edit .icon-actions svg {
-  width: 16px;
-  height: 16px;
+.abschnitt-icon-zone [data-action='edit'],
+.abschnitt-icon-zone [data-action='finish'] {
+  grid-column: 2;
 }
 
-.abschnitt-edit .actions mat-icon {
-  cursor: pointer;
+.abschnitt-icon-zone [data-action='delete'] {
+  grid-column: 3;
 }

--- a/src/app/feature/day-plan/abschnitt/abschnitt.spec.ts
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.spec.ts
@@ -49,12 +49,16 @@ describe('Abschnitt', () => {
       undefined,
     );
 
-    assert.ok(abschnitt.element.innerHTML.includes('08:00 - 12:00'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-start-hour>08<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-start-minute>00<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-end-hour>12<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-end-minute>00<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-location>Büro<'));
     assert.ok(abschnitt.element.querySelector('[data-action="edit"]'));
     assert.ok(abschnitt.element.querySelector('[data-action="delete"]'));
   });
 
-  it('renders an empty string when there is no section and not editing', () => {
+  it('defaults to zeroed time fields and "kein" when there is no section and not editing', () => {
     const abschnitt = createAbschnitt(
       undefined,
       undefined,
@@ -63,6 +67,8 @@ describe('Abschnitt', () => {
       undefined,
     );
 
+    assert.ok(abschnitt.element.innerHTML.includes('data-start-hour>00<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-location>kein<'));
     assert.ok(abschnitt.element.querySelector('[data-action="edit"]'));
   });
 
@@ -310,14 +316,25 @@ describe('Abschnitt', () => {
       LOCATIONS.UNASSIGNED,
     );
 
-    assert.equal(abschnitt.element.querySelector('[data-start-hour]'), null);
+    assert.equal(
+      abschnitt.element.querySelector('input[data-start-hour]'),
+      null,
+    );
 
     abschnitt.update(section, true);
 
-    assert.ok(abschnitt.element.querySelector('[data-start-hour]'));
+    assert.ok(abschnitt.element.querySelector('input[data-start-hour]'));
 
     abschnitt.update(section, false);
 
-    assert.ok(abschnitt.element.innerHTML.includes('01:02 - 03:04'));
+    assert.equal(
+      abschnitt.element.querySelector('input[data-start-hour]'),
+      null,
+    );
+    assert.ok(abschnitt.element.innerHTML.includes('data-start-hour>01<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-start-minute>02<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-end-hour>03<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-end-minute>04<'));
+    assert.ok(abschnitt.element.innerHTML.includes('data-location>kein<'));
   });
 });

--- a/src/app/feature/day-plan/abschnitt/abschnitt.ts
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.ts
@@ -1,5 +1,9 @@
 import type { Component } from '../../../component';
-import { LOCATIONS, type Location } from '../../../model/locations';
+import {
+  LOCATION_LABELS,
+  LOCATIONS,
+  type Location,
+} from '../../../model/locations';
 import { Section } from '../../../model/Section';
 import { Time } from '../../../model/Time';
 import { bindActions } from '../../../util/bind-actions';
@@ -25,37 +29,65 @@ export function createAbschnitt(
   let endMinute = section?.endTime?.minute ?? 0;
   let location: Location = section?.location ?? LOCATIONS.UNASSIGNED;
 
+  function renderTimeCell(
+    value: number,
+    dataAttr: string,
+    max: number,
+  ): string {
+    if (isEdit) {
+      return `<input class="abschnitt-time-cell" type="number" min="0" max="${max}" value="${value}" ${dataAttr} />`;
+    }
+    return `<span class="abschnitt-time-cell" ${dataAttr}>${value.toString().padStart(2, '0')}</span>`;
+  }
+
+  function renderLocationCell(): string {
+    if (isEdit) {
+      return `
+        <select class="abschnitt-location-cell" data-location>
+          <option value="${LOCATIONS.UNASSIGNED}" ${location === LOCATIONS.UNASSIGNED ? 'selected' : ''}>${LOCATION_LABELS[LOCATIONS.UNASSIGNED]}</option>
+          <option value="${LOCATIONS.OFFICE}" ${location === LOCATIONS.OFFICE ? 'selected' : ''}>${LOCATION_LABELS[LOCATIONS.OFFICE]}</option>
+          <option value="${LOCATIONS.MOBILE}" ${location === LOCATIONS.MOBILE ? 'selected' : ''}>${LOCATION_LABELS[LOCATIONS.MOBILE]}</option>
+        </select>`;
+    }
+    return `<span class="abschnitt-location-cell" data-location>${LOCATION_LABELS[location]}</span>`;
+  }
+
+  function renderIconZone(): string {
+    if (isEdit) {
+      return `
+        <div class="abschnitt-icon-zone">
+          <span data-action="abort">${icon('close')}</span>
+          <span data-action="finish">${icon('check')}</span>
+          <span data-action="delete">${icon('delete')}</span>
+        </div>`;
+    }
+    return `
+      <div class="abschnitt-icon-zone">
+        <span data-action="edit">${icon('edit')}</span>
+        <span data-action="delete">${icon('delete')}</span>
+      </div>`;
+  }
+
   function render() {
     el.classList.toggle('abschnitt-edit', isEdit);
-    if (isEdit) {
-      el.innerHTML = `
-        <div class="time-inputs">
-          <input type="number" min="0" max="23" value="${startHour}" data-start-hour />
-          <input type="number" min="0" max="59" value="${startMinute}" data-start-minute />
-          -
-          <input type="number" min="0" max="23" value="${endHour}" data-end-hour />
-          <input type="number" min="0" max="59" value="${endMinute}" data-end-minute />
-        </div>
-        <div class="actions">
-          <select data-location>
-            <option value="${LOCATIONS.UNASSIGNED}" ${location === LOCATIONS.UNASSIGNED ? 'selected' : ''}>kein</option>
-            <option value="${LOCATIONS.OFFICE}" ${location === LOCATIONS.OFFICE ? 'selected' : ''}>${LOCATIONS.OFFICE}</option>
-            <option value="${LOCATIONS.MOBILE}" ${location === LOCATIONS.MOBILE ? 'selected' : ''}>${LOCATIONS.MOBILE}</option>
-          </select>
-          <div class="icon-actions">
-            <span data-action="finish">${icon('check')}</span>
-            <span data-action="abort">${icon('close')}</span>
-            <span data-action="delete">${icon('delete')}</span>
-          </div>
-        </div>`;
-    } else {
-      el.innerHTML = `
-        ${section ? section.formattedString() : ''}
-        <span class="abschnitt-actions">
-          <span data-action="edit">${icon('edit')}</span>
-          <span data-action="delete">${icon('delete')}</span>
-        </span>`;
-    }
+    // The time-range cells are concatenated with no whitespace between them
+    // so the rendered text reads as "08:00 - 09:00" with no stray gaps
+    // around the colons/dash (a real browser turns template-literal
+    // whitespace between inline elements into visible text/layout gaps).
+    const timeRange =
+      renderTimeCell(startHour, 'data-start-hour', 23) +
+      '<span class="abschnitt-time-sep">:</span>' +
+      renderTimeCell(startMinute, 'data-start-minute', 59) +
+      '<span class="abschnitt-time-sep abschnitt-time-sep--range"> - </span>' +
+      renderTimeCell(endHour, 'data-end-hour', 23) +
+      '<span class="abschnitt-time-sep">:</span>' +
+      renderTimeCell(endMinute, 'data-end-minute', 59);
+    el.innerHTML = `
+      <div class="abschnitt-row">
+        <div class="abschnitt-time-range">${timeRange}</div>
+        ${renderLocationCell()}
+        ${renderIconZone()}
+      </div>`;
     bindEvents();
   }
 
@@ -125,6 +157,11 @@ export function createAbschnitt(
   function update(newSection: Section | undefined, newIsEdit: boolean): void {
     section = newSection;
     isEdit = newIsEdit;
+    startHour = section?.startTime?.hour ?? 0;
+    startMinute = section?.startTime?.minute ?? 0;
+    endHour = section?.endTime?.hour ?? 0;
+    endMinute = section?.endTime?.minute ?? 0;
+    location = section?.location ?? LOCATIONS.UNASSIGNED;
     render();
   }
 

--- a/src/app/model/locations.ts
+++ b/src/app/model/locations.ts
@@ -16,3 +16,12 @@ export type Location = (typeof LOCATIONS)[keyof typeof LOCATIONS];
 export const WORK_LOCATIONS: Location[] = Object.values(LOCATIONS).filter(
   (location) => location !== LOCATIONS.UNASSIGNED,
 );
+
+// Short display labels for the Abschnitteditor's view/edit location cell —
+// kept separate from the LOCATIONS values themselves so persisted data and
+// equality checks are unaffected by display-only abbreviations.
+export const LOCATION_LABELS: Record<Location, string> = {
+  [LOCATIONS.UNASSIGNED]: 'kein',
+  [LOCATIONS.OFFICE]: LOCATIONS.OFFICE,
+  [LOCATIONS.MOBILE]: LOCATIONS.MOBILE,
+};

--- a/src/app/test-utils.ts
+++ b/src/app/test-utils.ts
@@ -170,6 +170,20 @@ class FakeElement {
       return null;
     }
 
+    const tagWithAttr = selector.match(/^(\w+)\[([\w-]+)\]$/);
+    if (tagWithAttr) {
+      const [, tag, attr] = tagWithAttr;
+      const tagUpper = tag.toUpperCase();
+      for (const child of this.children) {
+        if (child.tagName === tagUpper && child.hasAttribute(attr)) {
+          return child;
+        }
+        const found = child.querySelector(selector);
+        if (found) return found;
+      }
+      return null;
+    }
+
     return null;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #545: the compact single-line fix landed there still felt cramped, truncated "mobil", shrank the edit-mode icons to 16px (inconsistent with the 24px used everywhere else), and reflowed visibly ("wobble") when entering edit mode. This PR redesigns the Abschnitteditor around a stable cell layout instead:

- **`src/app/feature/day-plan/abschnitt/abschnitt.ts` / `.scss`**: view and edit mode now render the same sequence of fixed-size cells (time cells, a location cell, a 3-slot icon zone). `isEdit` only swaps what's inside a cell (`<span>` vs. `<input>`/`<select>`), never its size or position. The icon zone reserves 3 CSS Grid columns unconditionally, so `delete` always sits in the same rightmost slot and `edit`/`finish` share the same middle slot — `abort` simply appears in the previously-empty first slot. Icons stay at their native 24×24. Time/location cells get `flex-shrink: 0` so neither can be squeezed asymmetrically between the span and input/select variants.
- **`src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.scss` / `.ts`**: fixes an overflow gap in the duration summary table's forced `white-space: nowrap` header that only showed up between 481–1023px viewport widths (missed in #545, which only tested the mobile and desktop breakpoints, not the gap between them).
- **`src/app/model/locations.ts`**: adds `LOCATION_LABELS` so the "kein" abbreviation for `LOCATIONS.UNASSIGNED` has a single source of truth instead of being duplicated between the view-mode cell and the edit-mode `<option>`.
- **`src/app/test-utils.ts`**: the fake DOM's `querySelector` gains support for compound `tag[attr]` selectors (e.g. `input[data-start-hour]`), needed because view mode now renders the same `data-*` hooks as edit mode, so tests need to distinguish the two by tag.
- **e2e**: adds 4 new Playwright-BDD scenarios tagged `@stable-layout` (no position shift on toggling edit mode, 24×24 icons, untruncated location select, single-line fit) and configures the Playwright config with one project per width in a spread (360–1280px) plus a dedicated `stable-layout-fairphone-4` project carrying real device data (411×756 CSS viewport, `deviceScaleFactor: 2.625`, matching Chrome Mobile/Android UA) — each project scoped via tag-grep to only run those 4 scenarios, so the rest of the suite still runs once on the existing `desktop` project.

## Test plan

- [x] `npm run build && npm test` — 70/70 unit tests pass, coverage 99.04% lines / 93.04% branches / 95.33% functions (all above threshold)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] Manually verified in a real browser (Playwright against the pre-installed Chromium, since the project's own e2e setup expects a `chrome-headless-shell` binary not present in this sandbox) that entering edit mode causes zero pixel movement for the delete icon, first time cell, and location cell, at both the tested width spread and the exact Fairphone 4 viewport/DPR/UA
- [x] Ran the full e2e suite (45 tests across all 9 projects, including `stable-layout-fairphone-4`) via a local-only `launchOptions.executablePath` override — all pass; that override is not part of this diff, `npm run e2e` should work as-is in a normal CI/dev environment

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnLNz9sHfs5b51E91tt8kX)_