### PR TITLE
Add happy-dom as devDependency (draft: candidate to replace fake DOM)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@playwright/test": "1.62.1",
         "@types/node": "24.13.3",
         "esbuild": "0.28.1",
+        "happy-dom": "^20.11.1",
         "playwright-bdd": "9.2.0",
         "sass-embedded": "1.100.0",
         "tsx": "4.23.1",
@@ -87,9 +88,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -107,9 +105,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -127,9 +122,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -147,9 +139,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -904,9 +893,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,9 +914,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,9 +935,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -976,9 +956,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1000,9 +977,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1024,9 +998,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,6 +1108,23 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -1496,6 +1484,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -1571,6 +1572,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -1644,6 +1658,25 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -2072,7 +2105,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2090,7 +2122,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2108,7 +2139,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2126,7 +2156,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2144,7 +2173,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2162,7 +2190,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2180,7 +2207,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2198,7 +2224,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2464,6 +2489,38 @@
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@playwright/test": "1.62.1",
     "@types/node": "24.13.3",
     "esbuild": "0.28.1",
+    "happy-dom": "^20.11.1",
     "playwright-bdd": "9.2.0",
     "sass-embedded": "1.100.0",
     "tsx": "4.23.1",


### PR DESCRIPTION
## Summary

This is an exploratory/draft PR. It adds [happy-dom](https://www.npmjs.com/package/happy-dom) as a devDependency and confirms it's a safe, low-cost addition. **happy-dom is not yet used anywhere** — the actual migration work is still open (see below).

## Why

`src/app/test-utils.ts` contains a hand-rolled `FakeElement`/`installFakeDocument` fake DOM (regex-based HTML parsing, ad-hoc `querySelector`/`querySelectorAll`, manual `classList`/`dataset`/event handling) used by:
- `src/app/feature/day-plan/abschnitt-liste/abschnitt-liste.spec.ts`
- `src/app/feature/day-plan/abschnitt-summe/abschnitt-summe.spec.ts`
- `src/app/feature/day-plan/abschnitt/abschnitt.spec.ts`
- `src/app/feature/day-plan/stempeluhr/stempeluhr.spec.ts`
- `src/app/day-plan.spec.ts`

The idea is to replace this custom fake DOM with `happy-dom`, a real (if lightweight) DOM implementation, for more faithful component tests (real CSS selector support, real event semantics, etc.) instead of maintaining bespoke DOM emulation.

## Dependency footprint investigation (done in this PR)

Before adding happy-dom, its cost was checked directly in this repo:

- **+6 transitive packages** on top of happy-dom itself: `ws`, `entities`, `whatwg-mimetype`, `buffer-image-size`, `@types/ws`, `@types/whatwg-mimetype` (153 → 160 packages in `package-lock.json`).
- **0 vulnerabilities** (`npm install` audit).
- **No peer dependency conflicts.** `ws`'s peer deps (`bufferutil`, `utf-8-validate`) are both declared `optional: true` in `peerDependenciesMeta`, so npm doesn't warn/error on them. happy-dom itself declares no peer deps, only `engines.node >= 20` (satisfied).
- `npm run typecheck`, `npm run lint`, `npm run build`, and `npm test` all pass unchanged with happy-dom present but unused.

## What's NOT done (left for follow-up work)

This PR intentionally stops at "dependency added, verified harmless." The actual migration still needs:

1. **Decide the test-setup approach.** happy-dom is typically wired in via a `GlobalRegistrator` (`happy-dom/register`) or by manually constructing a `Window`/`Document` per test. Given this project uses `node:test` (not Jest/Vitest, which happy-dom has first-class docs for), check how to integrate it with `node --import tsx` and `test-setup.ts` — likely registering `document`/`window` globally in `test-setup.ts` (which currently only stubs `localStorage`, `window`, and `URL.createObjectURL`/`revokeObjectURL`) rather than per-spec-file `installFakeDocument()`/`resetFakeDocument()` calls.
2. **Migrate the 5 spec files listed above** off `installFakeDocument()`/`resetFakeDocument()` (from `src/app/test-utils.ts`) onto happy-dom's real `document`. Check assumptions the fake DOM's tests may rely on that happy-dom's real parser/selectors won't reproduce identically (e.g. the fake's regex-based `_parseHTML`, its limited `querySelector` selector grammar, or its simplified `classList`/`dataset` — happy-dom will be stricter/more correct, which could surface latent bugs in the components under test, not just the tests).
3. **Delete `src/app/test-utils.ts`** once nothing references `installFakeDocument`/`resetFakeDocument`/`FakeElement` anymore.
4. **Re-check coverage thresholds** (`scripts/check-coverage.ts`, currently lines ≥78.63% / branches ≥92.14% / functions ≥87.61%) after the migration — `test-utils.ts` itself currently contributes coverage numbers (95.24/91.14/83.33 per the last full test run) that disappear once it's deleted, and the migrated spec files' coverage of the fake DOM's edge cases won't carry over 1:1.
5. Per `AGENTS.md`, this counts as a "new dependency" — already surfaced to the human before this PR was created ("Ask first" boundary), but worth reconfirming happy-dom is the desired end state (vs. e.g. `jsdom` or `linkedom`) before doing the full migration, since that's a bigger, harder-to-reverse change than this draft.

## Test plan

- [x] `npm install` — 0 vulnerabilities, no peer dep warnings
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` — coverage unchanged (99.23% / 93.29% / 95.35%), all specs pass
- [ ] Actual happy-dom usage / fake DOM removal (follow-up work, not in this PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYQcWpCSrM9PDT118ZY6Rh)_