### PR TITLE
Left-align section list column headers with their values

### DIFF
--- a/e2e/features/app.feature
+++ b/e2e/features/app.feature
@@ -90,6 +90,14 @@ Feature: Day plan page
     Then I see the column headers "Start", "Ende" and "Arbeitsort" above the section list
 
   @stable-layout
+  Scenario: The section list column headers are left-aligned with the section values
+    Given today's date is "2025-02-17" and the current time is "08:00:00"
+    When I open the day plan for today
+    And I log in
+    And I log out
+    Then the column headers are left-aligned with section "0"'s values
+
+  @stable-layout
   Scenario: Clocking in does not move the log button
     Given today's date is "2025-02-17" and the current time is "08:00:00"
     When I open the day plan for today

--- a/e2e/steps/app.steps.ts
+++ b/e2e/steps/app.steps.ts
@@ -274,6 +274,41 @@ Then(
   },
 );
 
+Then(
+  "the column headers are left-aligned with section {string}'s values",
+  async ({ page }, sectionIndex: string) => {
+    const header = page.locator('.abschnitt-liste__header');
+    const labelCells = header.locator(
+      '.abschnitt-time-cell:not(.abschnitt-liste__header-filler)',
+    );
+    const section = page.getByTestId(`section-${sectionIndex}`);
+    await section.waitFor();
+
+    const startHeaderBox = await labelCells.nth(0).boundingBox();
+    const endeHeaderBox = await labelCells.nth(1).boundingBox();
+    const arbeitsortHeaderBox = await header
+      .locator('.abschnitt-liste__header-location')
+      .boundingBox();
+    const startValueBox = await section
+      .locator('[data-start-hour]')
+      .boundingBox();
+    const endeValueBox = await section.locator('[data-end-hour]').boundingBox();
+    const arbeitsortValueBox = await section
+      .locator('[data-location]')
+      .boundingBox();
+
+    for (const [headerBox, valueBox] of [
+      [startHeaderBox, startValueBox],
+      [endeHeaderBox, endeValueBox],
+      [arbeitsortHeaderBox, arbeitsortValueBox],
+    ] as const) {
+      expect(headerBox).not.toBeNull();
+      expect(valueBox).not.toBeNull();
+      expect(headerBox!.x).toBeCloseTo(valueBox!.x, 0);
+    }
+  },
+);
+
 Given('I remember the position of the log button', async ({ page }) => {
   rememberedBoxes.set(
     page,

--- a/src/app/feature/day-plan/abschnitt/abschnitt.scss
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.scss
@@ -35,7 +35,7 @@
 .abschnitt-time-cell {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   box-sizing: border-box;
   width: 2.75rem;
   // An explicit height (rather than relying on content/padding to size the
@@ -51,7 +51,7 @@
   box-shadow: inset 0 0 0 1px transparent;
   font: inherit;
   font-variant-numeric: tabular-nums;
-  text-align: center;
+  text-align: left;
   -moz-appearance: textfield;
 
   &::-webkit-inner-spin-button,


### PR DESCRIPTION
Start/Ende were centered in a fixed-width cell shared by header and
data rows, so a 5-letter label and a 2-digit value never lined up at
the same left edge even though the boxes matched exactly. Switching
that cell to left alignment fixes Start/Ende/Arbeitsort for both
view and edit mode in one place.

Adds a @stable-layout e2e scenario asserting the header cells share
an x-position with the first section's values.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nhcb6ytu1Y3XjsYe2Ub4j6