### PR TITLE
Center colon between hour and minute in section time cells

### DIFF
--- a/e2e/features/app.feature
+++ b/e2e/features/app.feature
@@ -98,6 +98,14 @@ Feature: Day plan page
     Then the column headers are left-aligned with section "0"'s values
 
   @stable-layout
+  Scenario: The colon is evenly spaced between the hour and minute of a time
+    Given today's date is "2025-02-17" and the current time is "08:00:00"
+    When I open the day plan for today
+    And I log in
+    And I log out
+    Then the colon between hour and minute is evenly spaced for section "0"'s start and end time
+
+  @stable-layout
   Scenario: Clocking in does not move the log button
     Given today's date is "2025-02-17" and the current time is "08:00:00"
     When I open the day plan for today

--- a/e2e/steps/app.steps.ts
+++ b/e2e/steps/app.steps.ts
@@ -309,6 +309,44 @@ Then(
   },
 );
 
+async function textRect(
+  locator: ReturnType<Page['locator']>,
+): Promise<{ left: number; right: number }> {
+  return locator.first().evaluate((el) => {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const rect = range.getBoundingClientRect();
+    return { left: rect.left, right: rect.right };
+  });
+}
+
+Then(
+  "the colon between hour and minute is evenly spaced for section {string}'s start and end time",
+  async ({ page }, sectionIndex: string) => {
+    const section = page.getByTestId(`section-${sectionIndex}`);
+    await section.waitFor();
+    const seps = section.locator('.abschnitt-time-sep');
+
+    // DOM order (abschnitt.ts): start-hour, ":" (0), start-minute,
+    // " - " (1), end-hour, ":" (2), end-minute.
+    const pairs = [
+      { hour: '[data-start-hour]', sepIndex: 0, minute: '[data-start-minute]' },
+      { hour: '[data-end-hour]', sepIndex: 2, minute: '[data-end-minute]' },
+    ];
+
+    for (const { hour, sepIndex, minute } of pairs) {
+      const hourRect = await textRect(section.locator(hour));
+      const sepBox = await seps.nth(sepIndex).boundingBox();
+      const minuteRect = await textRect(section.locator(minute));
+
+      expect(sepBox).not.toBeNull();
+      const gapBefore = sepBox!.x - hourRect.right;
+      const gapAfter = minuteRect.left - (sepBox!.x + sepBox!.width);
+      expect(gapBefore).toBeCloseTo(gapAfter, 0);
+    }
+  },
+);
+
 Given('I remember the position of the log button', async ({ page }) => {
   rememberedBoxes.set(
     page,

--- a/src/app/feature/day-plan/abschnitt/abschnitt.scss
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.scss
@@ -66,6 +66,17 @@ input.abschnitt-time-cell {
   border-radius: 4px;
 }
 
+// Hour cells right-align their digits so they sit flush against the colon,
+// mirroring the minute cells' left-aligned digits on the colon's other
+// side — keeps the colon visually centered between hour and minute without
+// changing any cell's box geometry (width/height stay shared with the
+// input, per the @stable-layout guarantees above).
+.abschnitt-time-cell[data-start-hour],
+.abschnitt-time-cell[data-end-hour] {
+  justify-content: flex-end;
+  text-align: right;
+}
+
 // Shared by the view-mode <span> and the edit-mode <select>, same reasoning
 // as .abschnitt-time-cell above.
 .abschnitt-location-cell {


### PR DESCRIPTION
The hour and minute cells share a fixed-width box for stable-layout
reasons, but both were left-aligned, so leftover width inside the box
only showed up on the hour side (before the colon), making the gap
before the colon larger than the gap after it. Right-align the hour
cells so their digits sit flush against the colon on both sides,
without changing any cell's box geometry.