### PR TITLE
Fix PR #552's alignment regression by right-aligning minutes, not hours

### DIFF
--- a/e2e/steps/app.steps.ts
+++ b/e2e/steps/app.steps.ts
@@ -274,6 +274,17 @@ Then(
   },
 );
 
+async function textRect(
+  locator: ReturnType<Page['locator']>,
+): Promise<{ left: number; right: number }> {
+  return locator.first().evaluate((el) => {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const rect = range.getBoundingClientRect();
+    return { left: rect.left, right: rect.right };
+  });
+}
+
 Then(
   "the column headers are left-aligned with section {string}'s values",
   async ({ page }, sectionIndex: string) => {
@@ -306,19 +317,22 @@ Then(
       expect(valueBox).not.toBeNull();
       expect(headerBox!.x).toBeCloseTo(valueBox!.x, 0);
     }
+
+    // The cell boxes above are fixed-width regardless of text-align, so
+    // matching box positions alone doesn't prove the *glyphs* line up (see
+    // e.g. https://github.com/mohrm/workingdiary/pull/552, which right-
+    // aligned the hour digits inside an unchanged box and broke this
+    // visually without moving any box). Compare rendered text position too.
+    for (const [headerCell, valueSelector] of [
+      [labelCells.nth(0), '[data-start-hour]'],
+      [labelCells.nth(1), '[data-end-hour]'],
+    ] as const) {
+      const headerTextRect = await textRect(headerCell);
+      const valueTextRect = await textRect(section.locator(valueSelector));
+      expect(headerTextRect.left).toBeCloseTo(valueTextRect.left, 0);
+    }
   },
 );
-
-async function textRect(
-  locator: ReturnType<Page['locator']>,
-): Promise<{ left: number; right: number }> {
-  return locator.first().evaluate((el) => {
-    const range = document.createRange();
-    range.selectNodeContents(el);
-    const rect = range.getBoundingClientRect();
-    return { left: rect.left, right: rect.right };
-  });
-}
 
 Then(
   "the colon between hour and minute is evenly spaced for section {string}'s start and end time",

--- a/src/app/feature/day-plan/abschnitt/abschnitt.scss
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.scss
@@ -66,13 +66,16 @@ input.abschnitt-time-cell {
   border-radius: 4px;
 }
 
-// Hour cells right-align their digits so they sit flush against the colon,
-// mirroring the minute cells' left-aligned digits on the colon's other
-// side — keeps the colon visually centered between hour and minute without
-// changing any cell's box geometry (width/height stay shared with the
-// input, per the @stable-layout guarantees above).
-.abschnitt-time-cell[data-start-hour],
-.abschnitt-time-cell[data-end-hour] {
+// Hour cells stay left-aligned (inherited above) so their digits share a
+// left edge with the left-aligned "Start"/"Ende" column headers, which sit
+// in a same-width cell one row up (see abschnitt-liste.ts). Right-aligning
+// the minute cells instead moves their digits flush against the colon,
+// balancing the colon's left gap (hour digit to colon: leftover box width
+// + right padding) against its right gap (colon to minute digit: leftover
+// box width + left padding) — keeps the colon visually centered without
+// touching the hour cells' box geometry or their header alignment.
+.abschnitt-time-cell[data-start-minute],
+.abschnitt-time-cell[data-end-minute] {
   justify-content: flex-end;
   text-align: right;
 }


### PR DESCRIPTION
PR #552 right-aligned the hour cells to even out the colon gap, but
that undid PR #551's header/value alignment: hour digits moved to the
right edge of their box while the left-aligned "Start"/"Ende" headers
above them stayed put, drifting apart again.

Right-align the minute cells instead. Hour cells stay left-aligned
(matching the headers, both in box position and now in rendered glyph
position), and shifting the minute digits toward the colon balances
the same leftover box width on the other side, keeping the colon gap
symmetric without touching the hour cells at all.

PR #551's own e2e scenario didn't catch this because it compared
`.boundingBox()` of the fixed-width cell element, which never moves
when only `text-align`/`justify-content` changes inside it — only the
rendered text does. Strengthen that scenario's step to additionally
compare rendered text position (via the `textRect` Range-based helper
PR #552 already introduced for its own colon-spacing check), so a
future change that shifts glyphs inside an unchanged box fails loudly
instead of passing silently.