### PR TITLE
Widen the gap around a section's time-range separator past the colon gap

### DIFF
--- a/e2e/features/app.feature
+++ b/e2e/features/app.feature
@@ -106,6 +106,14 @@ Feature: Day plan page
     Then the colon between hour and minute is evenly spaced for section "0"'s start and end time
 
   @stable-layout
+  Scenario: The gap around the time range separator is clearly wider than around the colon
+    Given today's date is "2025-02-17" and the current time is "08:00:00"
+    When I open the day plan for today
+    And I log in
+    And I log out
+    Then the gap around the range separator is clearly wider than the colon gap for section "0"'s start and end time
+
+  @stable-layout
   Scenario: Clocking in does not move the log button
     Given today's date is "2025-02-17" and the current time is "08:00:00"
     When I open the day plan for today

--- a/e2e/steps/app.steps.ts
+++ b/e2e/steps/app.steps.ts
@@ -361,6 +361,52 @@ Then(
   },
 );
 
+Then(
+  "the gap around the range separator is clearly wider than the colon gap for section {string}'s start and end time",
+  async ({ page }, sectionIndex: string) => {
+    const section = page.getByTestId(`section-${sectionIndex}`);
+    await section.waitFor();
+    const seps = section.locator('.abschnitt-time-sep');
+
+    // DOM order (abschnitt.ts): start-hour, ":" (0), start-minute,
+    // " - " (1), end-hour, ":" (2), end-minute.
+    const startMinuteRect = await textRect(
+      section.locator('[data-start-minute]'),
+    );
+    const rangeSepBox = await seps.nth(1).boundingBox();
+    const endHourRect = await textRect(section.locator('[data-end-hour]'));
+    expect(rangeSepBox).not.toBeNull();
+
+    const rangeGapBefore = rangeSepBox!.x - startMinuteRect.right;
+    const rangeGapAfter =
+      endHourRect.left - (rangeSepBox!.x + rangeSepBox!.width);
+
+    // Compare against the larger of both colons' gaps in this section, so
+    // the assertion holds regardless of which colon happens to be wider
+    // and isn't a coin-flip on sub-pixel rounding.
+    const colonPairs = [
+      { hour: '[data-start-hour]', sepIndex: 0, minute: '[data-start-minute]' },
+      { hour: '[data-end-hour]', sepIndex: 2, minute: '[data-end-minute]' },
+    ];
+    const colonGaps: number[] = [];
+    for (const { hour, sepIndex, minute } of colonPairs) {
+      const hourRect = await textRect(section.locator(hour));
+      const colonSepBox = await seps.nth(sepIndex).boundingBox();
+      const minuteRect = await textRect(section.locator(minute));
+      expect(colonSepBox).not.toBeNull();
+      colonGaps.push(colonSepBox!.x - hourRect.right);
+      colonGaps.push(minuteRect.left - (colonSepBox!.x + colonSepBox!.width));
+    }
+    const maxColonGap = Math.max(...colonGaps);
+
+    // Comfortably clears rounding noise so this is a real regression guard,
+    // not a bare `>`.
+    const MARGIN_PX = 4;
+    expect(rangeGapBefore).toBeGreaterThan(maxColonGap + MARGIN_PX);
+    expect(rangeGapAfter).toBeGreaterThan(maxColonGap + MARGIN_PX);
+  },
+);
+
 Given('I remember the position of the log button', async ({ page }) => {
   rememberedBoxes.set(
     page,

--- a/src/app/feature/day-plan/abschnitt/abschnitt.scss
+++ b/src/app/feature/day-plan/abschnitt/abschnitt.scss
@@ -30,6 +30,31 @@
   padding: 0 1px;
 }
 
+// The gap on both sides of the range separator (" - ", between a section's
+// start and end time) must read as clearly *wider* than the gap around each
+// colon (between an hour and its minute) — otherwise the eye tries to group
+// a start time's minute with the end time's hour instead of grouping
+// hour+minute within each time. Padding wouldn't help here: `.abschnitt-
+// time-range` is a flex row with no `gap`, so adjacent cell boxes always
+// touch — padding only grows this element's own box inward, it never
+// pushes the neighboring minute/hour cell further away. `margin` does,
+// because in flex layout it sits outside the box.
+//
+// The colon's own gap isn't fixed width: it comes from leftover space in
+// `.abschnitt-time-cell`'s fixed 2.75rem box (sized to fit "Start"/"Ende"
+// text, not just 2 digits), so it grows as the responsive base font-size
+// shrinks — largest at narrow/mobile viewports, where the row's
+// single-line width budget is also tightest. Verified via the
+// "@stable-layout" e2e scenario comparing this gap against the colon gap
+// across the full configured viewport spread.
+.abschnitt-time-sep--range {
+  // Larger than the spacing scale's largest step ($spacing-xl, 12px):
+  // measurement showed the colon's gap peaks around 21-22px at narrow
+  // viewports (see e2e scenario below), so this needs enough margin to
+  // clear that with a comfortable buffer on both sides of the separator.
+  margin: 0 24px;
+}
+
 // Shared by the view-mode <span> and the edit-mode <input> so toggling
 // between them never changes this cell's box size or position.
 .abschnitt-time-cell {


### PR DESCRIPTION
PR #553 balanced the colon's flanking gap by right-aligning minute
cells, but that pushed all of the fixed-width time cell's leftover
space (reserved to fit the "Start"/"Ende" header labels) to flank the
colon — leaving the " - " separator between a section's start and end
time with only its neighbors' own padding, no leftover. The colon
ended up with more surrounding whitespace than the separator between
the two times, so the eye tries to group a start time's minute with
the end time's hour instead of reading each HH:MM as one unit.

Give .abschnitt-time-sep--range a wide margin (padding wouldn't work:
.abschnitt-time-range has no flex gap, so adjacent boxes touch and
padding only grows the separator's own box inward). Sized against the
measured worst case, where the colon's leftover-driven gap peaks
around 21-22px at narrow/mobile viewports.

Add a @stable-layout e2e scenario asserting the range-separator gap
beats the colon gap by a comfortable margin, verified across the full
configured viewport spread (360-1280px, including the Fairphone 4
profile) with no regression to colon symmetry, header/value alignment,
or the section row's single-line fit.